### PR TITLE
fixed video slider issue

### DIFF
--- a/src/components/VideoPlayerSegment.tsx
+++ b/src/components/VideoPlayerSegment.tsx
@@ -51,7 +51,7 @@ export const VideoPlayerSegment: FunctionComponent<VideoProps> = ({
       if (mouseTimeDisplay) {
         const timeTooltip: any = mouseTimeDisplay.getChild('timeTooltip');
         if (timeTooltip) {
-          timeTooltip.update = function(
+          timeTooltip.update = function (
             seekBarRect: any,
             seekBarPoint: any,
             time: string
@@ -70,6 +70,8 @@ export const VideoPlayerSegment: FunctionComponent<VideoProps> = ({
               this.el().style.left = 'auto';
               this.el().style.width = '200px'
               this.el().style.fontSize = '14px'
+              this.el().style.lineHeight = '1'
+              this.el().style.wordWrap = 'break-word'
             }, 0);
           };
         } else {


### PR DESCRIPTION
Fixed #1 

By default the line height was set to 0. I have changed the line height to 1 and now text is not overlapping in slider. I have also added word-wrap property to stop text from overflowing when words are too long.

<img width="1440" alt="Screenshot 2024-02-01 at 6 21 58 PM" src="https://github.com/code100x/cms/assets/84085728/4352f34d-b362-4142-bcf5-67cb2fc1a5e0">
