### PR TITLE
[Bugfix] Overlapping issue in Video Slider

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,7 +70,7 @@ export const createSegmentMarkerElements = (
   lastSegment: Segment,
 ) => {
   const segmentEnd = isFinite(segment.end)
-    ? (segment.end / (player.duration() || lastSegment.end)) * 100
+    ? ((segment.end + 1) / (player.duration() || lastSegment.end)) * 100
     : 100;
 
   // Create gap element


### PR DESCRIPTION
This PR addresses issue #1.

The video slider was overlapping due to the end segment of the slider being placed at the start of the nth second, rather than at the end.

For instance, consider the following segment data:

```
 const segmentsData = [{
    start:0,
    end:3,
    title:"Test - 1"
  },{
    start:4,
    end:6,
    title:"Test - 2"
  },{
    start:7,
    end:10,
    title:"Final Test"
  }
];

```

In the first segment, where the end time is 3 seconds, the current code begins the segment at the start of the 3rd second. Each second contains 1000ms, and this was causing the segments to overlap.

To resolve this issue, I added 1s to the end segment. Consequently, the segment now starts at the end of the nth second, which corrects the problem.

Current Issue which exists in 100xDevs video player:
![image](https://github.com/code100x/cms/assets/34382211/8df85a69-d209-4395-91df-2a5b9f1f4a6f)

After Implementation:
https://github.com/code100x/cms/assets/34382211/fdec7ea1-be8f-4abe-8f58-471e24b2943a


Note: When providing the segment data, keep in mind that segments shouldn't collide at the end of time, as this will lead to overlap issues. If you want me to add an additional method to ensure this end time does not collide with another segment and is within the video duration, please let me know and I will add those checks.

