### PR TITLE
[BugFix] The video doesn't fill the screen in full-screen mode.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,17 +77,3 @@
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {
     display:none;
 }
-
-.video-js.vjs-fluid,
-.video-js.vjs-16-9,
-.video-js.vjs-4-3,
-video.video-js,
-video.vjs-tech {
-  max-height: calc(100vh - 100px);
-  position: relative !important;
-  width: 100%;
-  height: auto !important;
-  max-width: 100% !important;
-  padding-top: 0 !important;
-  line-height: 0;
-}


### PR DESCRIPTION
This PR fixes #21 

Reason for issue:
This issue occurs because of a conflict in CSS due to the use of the !important keyword. To resolve this, I removed the specific code as it was not necessary.


Issue:
![image](https://github.com/code100x/cms/assets/34382211/340adc68-4a03-4b5e-b3c1-b0d87abe08a1)

Fix:
![image](https://github.com/code100x/cms/assets/34382211/831506a1-593f-498e-bd4c-c0142768a0e7)


// @hkirat Please have a look at this PR.
