### PR TITLE
[Bugfix] Workflow Fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,9 +68,8 @@ rules:
   # stylistic errors
   no-spaced-func: 2
   semi-spacing: 2
-  quotes: [2, 'single']
+  quotes: [2, 'double']
   key-spacing: [2, { beforeColon: false, afterColon: true }]
-  indent: [2, 2]
   no-lonely-if: 2
   no-floating-decimal: 2
   brace-style: [2, 1tbs, { allowSingleLine: true }]
@@ -88,7 +87,7 @@ rules:
   space-unary-ops: [2, {words: true, nonwords: false}]
   wrap-regex: 2
   linebreak-style: 0
-  semi: [2, always]
+  semi: [2, never]
   arrow-spacing: [2, {before: true, after: true}]
   no-class-assign: 2
   no-const-assign: 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,5 @@
 name: Linting and formatting on PR
-on:
-  pull_request:
-    branches:
-      - '**'
-    
+on: [ push ]
 jobs:
 
   Continuous-Integration:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "semi": false,
-  "singleQuote": true,
+  "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "all"
 }


### PR DESCRIPTION
fix #19 

This PR addresses two issues:

1. The requirement is to run the workflow on each pull request made to this repository. To achieve this, we need to use the `push` trigger instead of `pull_request`.
2. It resolves several conflicts between eslint and prettier.
a. It changes single quotes to double quotes.
b. The eslint indentation check is removed as prettier and eslint indent do not work together due to differing indentation styles. Reference: https://stackoverflow.com/questions/56337176/prettier-and-eslint-indents-not-working-together

To review whether this workflow is functioning correctly, you can check here: https://github.com/sahilsuman933/cms/actions/runs/7750601270/job/21137093903 and https://github.com/sahilsuman933/cms/pull/2

Note: This PR will show format issues as all the files are not formatted using prettier. I will create a separate PR to address all the formatting issues to avoid cluttering this PR.