### PR TITLE
fix: Landing page Image & Course card UI

### DIFF
--- a/src/components/3dcard.tsx
+++ b/src/components/3dcard.tsx
@@ -50,10 +50,7 @@ export const CardContainer = ({
   return (
     <MouseEnterContext.Provider value={[isMouseEntered, setIsMouseEntered]}>
       <div
-        className={cn(
-          'py-20 flex items-center justify-center',
-          containerClassName,
-        )}
+        className={cn('flex items-center justify-center', containerClassName)}
         style={{
           perspective: '1000px',
         }}

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -18,17 +18,6 @@ export const CourseCard = ({
         onClick();
       }}
     >
-      <div className="relative">
-        {course.totalVideos !== undefined &&
-          course.totalVideosWatched !== undefined && (
-          <PercentageComplete
-            percent={Math.ceil(
-              (course.totalVideosWatched / course.totalVideos) * 100,
-            )}
-          />
-        )}
-        <img src={course.imageUrl} alt={course.title} className="rounded-md" />
-      </div>
       <div className="p-2">
         <img
           src={course.imageUrl}
@@ -37,7 +26,15 @@ export const CourseCard = ({
         />
       </div>
 
-      <div className="px-6 py-2 w-full h-full">
+      {/* <div className="p-2">
+        <img
+          src={course.imageUrl}
+          alt={course.title}
+          className="rounded-t-md md:rounded-l-md md:rounded-r-none md:max-w-md"
+        />
+      </div> */}
+
+      <div className="px-4 md:px-6 py-2 w-full h-full">
         <div className="flex flex-col w-full h-full items-start justify-between md:py-4">
           <div className="w-full items-start mb-3">
             <h2 className="mb-0 md:mb-2 dark:text-neutral-100 text-neutral-800 text-xl sm:text-3xl font-semibold">
@@ -49,11 +46,22 @@ export const CourseCard = ({
             </p>
           </div>
 
-          <div className="w-full flex justify-end pb-2 md:pb-0">
-            <Button className="group">
-              Explore Content{' '}
-              <ChevronRight className="h-4 w-4 ml-1 group-hover:translate-x-1 transition" />
-            </Button>
+          <div className="w-full flex items-center justify-between pb-2 md:pb-0">
+            {course.totalVideos !== undefined &&
+              course.totalVideosWatched !== undefined && (
+              <PercentageComplete
+                percent={Math.ceil(
+                  (course.totalVideosWatched / course.totalVideos) * 100,
+                )}
+              />
+            )}
+
+            <div className="w-full flex justify-end">
+              <Button className="group">
+                Explore Content{' '}
+                <ChevronRight className="h-4 w-4 ml-1 group-hover:translate-x-1 transition" />
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/PercentageComplete.tsx
+++ b/src/components/PercentageComplete.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
-
 const PercentageComplete = ({ percent }: { percent: number }) => {
   return (
-    <div className="text-xs absolute top-2 right-2 text-[#1D4ED8] border-[#1D4ED8] border py-1 px-2 rounded-full font-bold">
-      <div>{`${percent}% completed`}</div>
+    <div className="w-full text-sm flex items-center justify-center text-blue-600 py-1 px-2 rounded-full font-semibold">
+      <div className="w-full">{`${percent}% completed`}</div>
     </div>
   );
 };

--- a/src/components/landing/snaps-section/platform/platform-section.tsx
+++ b/src/components/landing/snaps-section/platform/platform-section.tsx
@@ -12,7 +12,7 @@ const PlatformSection = () => {
         {/* // <CardBody className="relative group/card  dark:hover:shadow-2xl dark:hover:shadow-emerald-500/[0.1] dark:bg-black dark:border-white/[0.2] border-black/[0.1] w-full sm:w-[30rem] h-auto rounded-xl p-6 border  "> */}
         <div className="w-full flex items-center justify-center my-20">
           <div className="mx-2 p-3 md:p-6 bg-gradient-to-t from-slate-300 dark:from-slate-700 to-slate-400 dark:to-slate-600 rounded-xl md:rounded-2xl border shadow-xl">
-            <CardItem translateZ="100" className="w-full mt-4">
+            <CardItem translateZ="100" className="w-full">
               <Image
                 src={platform}
                 alt={'platform'}


### PR DESCRIPTION
fixes #67 

- Removed Extra space from top 

<img width="1470" alt="Screenshot 2024-02-04 at 8 52 37 AM" src="https://github.com/code100x/cms/assets/114291962/c39194f9-b8bc-43c5-88c1-38590d80fa5e">


- Removed extra image, instead of showing progress on the image itself, we are now showing it on the card

<img width="1470" alt="Screenshot 2024-02-04 at 8 54 29 AM" src="https://github.com/code100x/cms/assets/114291962/2b5e5c67-57f1-47b7-a499-b7bba1ee6d2f">
