### PR TITLE
disble download for VideoPlayer2.tsx

### DIFF
--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -147,6 +147,21 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
 
     document.addEventListener('keydown', handleKeyPress);
 
+    // Disables the right click for video downloading
+    const handleContextMenu = (event) => {
+      event.preventDefault(); // Prevent the default right-click behavior
+    };
+  
+    if (playerRef.current) {
+      playerRef.current.on('contextmenu', handleContextMenu);
+    }
+  
+    return () => {
+      if (playerRef.current) {
+        playerRef.current.off('contextmenu', handleContextMenu);
+      }
+    };
+    
     // Cleanup function
     return () => {
       document.removeEventListener('keydown', handleKeyPress);


### PR DESCRIPTION
Disabled Right click on video component so user can't directly download the lectures uploaded to prevent piracy.
(There was no issue for this pull request, i felt this needs to be added so i added and tested it)