### PR TITLE
fix: able to login without credentials (signin field validation missing)

### DIFF
--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -11,6 +11,10 @@ import React, { useRef, useState } from 'react';
 import { toast } from 'sonner';
 const Signin = () => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [requiredError, setRequiredError] = useState({
+    emailReq: false,
+    passReq: false,
+  });
 
   function togglePasswordVisibility() {
     setIsPasswordVisible((prevState: any) => !prevState);
@@ -20,6 +24,15 @@ const Signin = () => {
   const password = useRef('');
   const handleSubmit = async (e: React.FormEvent<HTMLButtonElement>) => {
     e.preventDefault();
+
+    if (!email.current || !password.current) {
+      setRequiredError({
+        emailReq: email.current ? false : true,
+        passReq: password.current ? false : true,
+      });
+      return;
+    }
+
     const res = await signIn('credentials', {
       username: email.current,
       password: password.current,
@@ -51,8 +64,17 @@ const Signin = () => {
                 name="email"
                 id="email"
                 placeholder="name@email.com"
-                onChange={(e) => (email.current = e.target.value)}
+                onChange={(e) => {
+                  setRequiredError((prevState) => ({
+                    ...prevState,
+                    emailReq: false,
+                  }));
+                  email.current = e.target.value;
+                }}
               />
+              {requiredError.emailReq && (
+                <span className=" text-red-500">Email is required</span>
+              )}
             </div>
             <div className="flex flex-col gap-4">
               <Label>Password</Label>
@@ -63,7 +85,13 @@ const Signin = () => {
                   type={isPasswordVisible ? 'text' : 'password'}
                   id="password"
                   placeholder="••••••••"
-                  onChange={(e) => (password.current = e.target.value)}
+                  onChange={(e) => {
+                    setRequiredError((prevState) => ({
+                      ...prevState,
+                      passReq: false,
+                    }));
+                    password.current = e.target.value;
+                  }}
                 />
                 <button
                   className="inset-y-0 right-0 flex items-center px-4 text-gray-600"
@@ -107,6 +135,9 @@ const Signin = () => {
                   )}
                 </button>
               </div>
+              {requiredError.passReq && (
+                <span className=" text-red-500">Password is required</span>
+              )}
             </div>
           </div>
           <Button className="my-3 w-full" onClick={handleSubmit}>


### PR DESCRIPTION
I have added the check for ensuring email and password are non-emty/not-null. And in case they are null (if user didn't provide them), then added the logic to show error message below respected form fields to ask him for the same, and prevent him from moving ahead in such case.

Error message when fields are left blank.
![after fix](https://github.com/code100x/cms/assets/98813758/8d0b3fde-8b44-4780-adbf-837de76635a6)

Error goes away when user starts typing
![after fix2](https://github.com/code100x/cms/assets/98813758/5eff44ae-1599-4482-886f-2b18fbaba7fc)
