### PR TITLE
Introducing simple role based access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,4 @@ BOT_TOKEN = "123"
 GUILD_ID = "123"
 LOCAL_CMS_PROVIDER = true
 CACHE_EXPIRE_S = 10
-
+ADMINS = "Random,example@gmail.com"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
+  react-hook-form:
+    specifier: ^7.50.1
+    version: 7.51.0(react@18.2.0)
   react-notion-x:
     specifier: ^6.16.0
     version: 6.16.0(@babel/runtime@7.23.9)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)(webpack@5.90.1)
@@ -3719,6 +3722,15 @@ packages:
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+    dev: false
+
+  /react-hook-form@7.51.0(react@18.2.0):
+    resolution: {integrity: sha512-BggOy5j58RdhdMzzRUHGOYhSz1oeylFAv6jUSG86OvCIvlAvS7KvnRY7yoAf2pfEiPN7BesnR0xx73nEk3qIiw==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-hotkeys-hook@3.4.7(react-dom@18.2.0)(react@18.2.0):

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -134,6 +134,11 @@ export const authOptions = {
       if (session?.user) {
         session.user.id = token.uid;
         session.user.jwtToken = token.jwtToken;
+        session.user.role = process.env.ADMINS?.split(',').includes(
+          session.user.email,
+        )
+          ? 'admin'
+          : 'user';
       }
 
       return session;


### PR DESCRIPTION
This pr introduces simple role based access that can be improved further.

Role based access will allow us to improve the admin dashboard and render components/tags based on the role in the session.

How it works: 

Add `ADMINS` field in .env, like in the example: 

`ADMINS = "Random,example@gmail.com,..."`

on login it does check if the current user is included in the admin list 