### PR TITLE
fix-ci pipeline should fail on PR if lint fails - #172

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: Run linting check
-        run: npm run lint:fix
+        run: npm run lint:check
 
       - name: Check formatting
         run: npm run format:fix


### PR DESCRIPTION
Fixes : #172 

Fail the job if `lint:check` exits with a non-zero code