### PR TITLE
fix: docker compose up failing on localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .pnp.js
 .yarn/install-state.gz
 
+# docker volume
+/postgres-data/
+
 # testing
 /coverage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,12 @@ services:
       - .:/usr/src/app
       - /usr/src/app/node_modules
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db:
     image: postgres:9.6
+    container_name: db
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -23,4 +25,9 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - /postgres-data:/var/lib/postgresql/data
+      - ./postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-U","postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U","postgres"]
+      test: [ 'CMD-SHELL', 'pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}' ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixes [#181](https://github.com/code100x/cms/issues/181)


### Issue - Docker compose fails locally with 2 errors

#### Issue #1:

`Error response from daemon: Mounts denied
The path /postgres-data is not shared from the host and is not known to Docker.`

![Screenshot 2024-03-10 at 4 45 57 PM](https://github.com/code100x/cms/assets/67855887/8bbb8dbd-a85b-4cc5-9ec1-1af10187655d)

#### Solution:

Changing 
`    volumes:
      - /postgres-data:/var/lib/postgresql/data
`
to 
`    volumes:
      - ./postgres-data:/var/lib/postgresql/data
`


#### Issue #2:
cms-docker: Error P1001: Can't reach database server at 'db':'5432'
Please make sure your database server is running at `db`:`5432`
![Screenshot 2024-03-10 at 5 14 13 PM](https://github.com/code100x/cms/assets/67855887/a4c52f1f-ccf7-4595-955e-97c6b03b953e)

#### Solution:
- Add health check condition for db in `depends_on` to ensure docker-cms runs only after docker-db is up and ready.
- Add health check to postgres docker container

#### Additional resources:
- https://www.warp.dev/terminus/docker-compose-depends-on
- https://github.com/peter-evans/docker-compose-healthcheck




