### PR TITLE
Feature: Dynamic Cache Entry Expiry

### DIFF
--- a/src/db/Cache.ts
+++ b/src/db/Cache.ts
@@ -13,7 +13,7 @@ export class Cache {
     return Cache.instance;
   }
 
-  set(type: string, args: string[], value: any, expiryInSeconds: number = 3600): void {
+  set(type: string, args: string[], value: any, expiryInSeconds: number = parseInt(process.env.CACHE_EXPIRE_S || '100', 10)): void {
     const currentTime = new Date().getTime();
     const expiry = currentTime + expiryInSeconds * 1000;
     this.inMemoryDb.set(`${type} ${JSON.stringify(args)}`, { value, expiry });
@@ -22,14 +22,12 @@ export class Cache {
   get(type: string, args: string[]): any | null {
     const key = `${type} ${JSON.stringify(args)}`;
     const cacheEntry = this.inMemoryDb.get(key);
-    if (cacheEntry) {
-      if (cacheEntry.expiry > new Date().getTime()) {
+    if (cacheEntry && cacheEntry.expiry > new Date().getTime()) {
         return cacheEntry.value;
-      } else {
+    } else {
         this.inMemoryDb.delete(key);
-      }
+        return null;
     }
-    return null;
   }
 
   evict(type: string, args: string[]): void {

--- a/src/db/Cache.ts
+++ b/src/db/Cache.ts
@@ -1,50 +1,43 @@
 export class Cache {
-  private inMemoryDb: Map<
-    string,
-    {
-      value: any;
-      expiry: number;
-    }
-  >;
+  private inMemoryDb: Map<string, { value: any; expiry: number; }>;
   private static instance: Cache;
 
   private constructor() {
-    this.inMemoryDb = new Map<
-      string,
-      {
-        value: any;
-        expiry: number;
+    this.inMemoryDb = new Map();
+  }
+
+  static getInstance(): Cache {
+    if (!Cache.instance) {
+      Cache.instance = new Cache();
+    }
+    return Cache.instance;
+  }
+
+  set(type: string, args: string[], value: any, expiryInSeconds: number = 3600): void {
+    const currentTime = new Date().getTime();
+    const expiry = currentTime + expiryInSeconds * 1000;
+    this.inMemoryDb.set(`${type} ${JSON.stringify(args)}`, { value, expiry });
+  }
+
+  get(type: string, args: string[]): any | null {
+    const key = `${type} ${JSON.stringify(args)}`;
+    const cacheEntry = this.inMemoryDb.get(key);
+    if (cacheEntry) {
+      if (cacheEntry.expiry > new Date().getTime()) {
+        return cacheEntry.value;
+      } else {
+        this.inMemoryDb.delete(key);
       }
-    >();
-  }
-  static getInstance() {
-    if (!this.instance) {
-      this.instance = new Cache();
     }
-
-    return this.instance;
+    return null;
   }
 
-  set(type: string, args: string[], value: any) {
-    this.inMemoryDb.set(`${type} ${JSON.stringify(args)}`, {
-      value,
-      expiry:
-        new Date().getTime() +
-        parseInt(process.env.CACHE_EXPIRE_S || '100', 10) * 1000,
-    });
+  evict(type: string, args: string[]): void {
+    const key = `${type} ${JSON.stringify(args)}`;
+    this.inMemoryDb.delete(key);
   }
 
-  get(type: string, args: string[]) {
-    const value = this.inMemoryDb.get(`${type} ${JSON.stringify(args)}`);
-    if (!value) {
-      return null;
-    }
-    if (new Date().getTime() > value.expiry) {
-      this.inMemoryDb.delete(`${type} ${JSON.stringify(args)}`);
-      return null;
-    }
-    return value.value;
+  clearAll(): void {
+    this.inMemoryDb.clear();
   }
-
-  evict() {}
 }

--- a/src/db/Cache.ts
+++ b/src/db/Cache.ts
@@ -1,41 +1,52 @@
 export class Cache {
-  private inMemoryDb: Map<string, { value: any; expiry: number; }>;
+  private inMemoryDb: Map<
+    string,
+    {
+      value: any;
+      expiry: number;
+    }
+  >;
   private static instance: Cache;
 
   private constructor() {
-    this.inMemoryDb = new Map();
+    this.inMemoryDb = new Map<
+      string,
+      {
+        value: any;
+        expiry: number;
+      }
+    >();
   }
 
-  static getInstance(): Cache {
-    if (!Cache.instance) {
-      Cache.instance = new Cache();
+  static getInstance() {
+    if (!this.instance) {
+      this.instance = new Cache();
     }
-    return Cache.instance;
+
+    return this.instance;
   }
 
-  set(type: string, args: string[], value: any, expiryInSeconds: number = parseInt(process.env.CACHE_EXPIRE_S || '100', 10)): void {
-    const currentTime = new Date().getTime();
-    const expiry = currentTime + expiryInSeconds * 1000;
-    this.inMemoryDb.set(`${type} ${JSON.stringify(args)}`, { value, expiry });
+  set(type: string, args: string[], value: any, expirySeconds: number = parseInt(process.env.CACHE_EXPIRE_S || '100', 10)) {
+    this.inMemoryDb.set(`${type} ${JSON.stringify(args)}`, {
+      value,
+      expiry: new Date().getTime() + expirySeconds * 1000,
+    });
   }
 
-  get(type: string, args: string[]): any | null {
+  get(type: string, args: string[]) {
     const key = `${type} ${JSON.stringify(args)}`;
-    const cacheEntry = this.inMemoryDb.get(key);
-    if (cacheEntry && cacheEntry.expiry > new Date().getTime()) {
-        return cacheEntry.value;
-    } else {
-        this.inMemoryDb.delete(key);
-        return null;
+    const entry = this.inMemoryDb.get(key);
+    if (!entry) {
+      return null;
     }
+    if (new Date().getTime() > entry.expiry) {
+      this.inMemoryDb.delete(key);
+      return null;
+    }
+    return entry.value;
   }
 
-  evict(type: string, args: string[]): void {
-    const key = `${type} ${JSON.stringify(args)}`;
-    this.inMemoryDb.delete(key);
-  }
+  evict() {
 
-  clearAll(): void {
-    this.inMemoryDb.clear();
   }
 }


### PR DESCRIPTION
This pull request enhances the existing Cache utility by introducing the capability to set dynamic expiry times fvor each cache entry. Previously the cache expiry time was statically set, limiting the utility's flexibility. With this update, users can specify the expiry time in seconds for each set operation, allowing for more nuanced cache control tailored to specific need. 

