### PR TITLE
fix : #216 - Mark as Complete button and checkbox UI sync 

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -59,8 +59,6 @@ export function Sidebar({
     const pathArray = findPathToContent(fullCourseContent, contentId);
     if (pathArray) {
       const path = `/courses/${courseId}/${pathArray.join('/')}`;
-      console.log(`Path is this ${path}`);
-      
       router.push(path);
     }
   };
@@ -255,7 +253,7 @@ function Check({ content , pathCheck } : { content: any  , pathCheck : any}) {
     <>
       <input
         checked={markAsComplete.isValid && markAsComplete?.path === pathCheck(content.id) ? markAsComplete.isCompleted : completed}
-        onClick={async (e) => {
+        onChange={async (e) => {
           setCompleted(!completed);
           handleMarkAsCompleted(!completed, content.id);
           setMarkAsComplete({

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import {
   Accordion,
   AccordionContent,
@@ -13,6 +13,7 @@ import { useRecoilState } from 'recoil';
 import { sidebarOpen as sidebarOpenAtom } from '@/store/atoms/sidebar';
 import { useEffect, useState } from 'react';
 import { handleMarkAsCompleted } from '@/lib/utils';
+import { markAsCompleteAtom } from '@/store/atoms/markAsComplete';
 
 export function Sidebar({
   courseId,
@@ -58,9 +59,19 @@ export function Sidebar({
     const pathArray = findPathToContent(fullCourseContent, contentId);
     if (pathArray) {
       const path = `/courses/${courseId}/${pathArray.join('/')}`;
+      console.log(`Path is this ${path}`);
+      
       router.push(path);
     }
   };
+  const getContentPath = (contentId: any) => {
+    const pathArray = findPathToContent(fullCourseContent, contentId);
+    if (pathArray) {
+      return `/courses/${courseId}/${pathArray.join('/')}`;
+      
+    }
+  };
+ 
 
   const renderContent = (contents: any) => {
     return contents.map((content: any) => {
@@ -101,7 +112,7 @@ export function Sidebar({
             </div>
             {content.type === 'video' ? (
               <div className="flex flex-col justify-center ml-2">
-                <Check content={content} />
+                <Check content={content} pathCheck = {getContentPath}/>
               </div>
             ) : null}
           </div>
@@ -232,17 +243,26 @@ function NotionIcon() {
 }
 
 // Todo: Fix types here
-function Check({ content }: { content: any }) {
+function Check({ content , pathCheck } : { content: any  , pathCheck : any}) {
   const [completed, setCompleted] = useState(
     content?.videoProgress?.markAsCompleted || false,
-  );
+  ); 
+  const [currentPath] = useState(usePathname());
+  const [markAsComplete , setMarkAsComplete] = useRecoilState(markAsCompleteAtom);
+
+
   return (
     <>
       <input
-        defaultChecked={completed}
+        checked={markAsComplete.isValid && markAsComplete?.path === pathCheck(content.id) ? markAsComplete.isCompleted : completed}
         onClick={async (e) => {
           setCompleted(!completed);
           handleMarkAsCompleted(!completed, content.id);
+          setMarkAsComplete({
+            isValid : true,
+            path : currentPath,
+            isCompleted : !completed
+          })
           e.stopPropagation();
         }}
         type="checkbox"

--- a/src/components/admin/ContentRendererClient.tsx
+++ b/src/components/admin/ContentRendererClient.tsx
@@ -1,10 +1,12 @@
 'use client';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 // import { QualitySelector } from '../QualitySelector';
 import { VideoPlayerSegment } from '@/components/VideoPlayerSegment';
 import VideoContentChapters from '../VideoContentChapters';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { handleMarkAsCompleted } from '@/lib/utils';
+import { useRecoilState } from 'recoil';
+import { markAsCompleteAtom } from '@/store/atoms/markAsComplete';
 
 export const ContentRendererClient = ({
   metadata,
@@ -70,7 +72,10 @@ export const ContentRendererClient = ({
       type: 'video/mp4',
     };
   }
+  const [currentPath] = useState(usePathname());
+  const [markAsComplete , setMarkAsComplete] = useRecoilState(markAsCompleteAtom);
 
+ 
   const toggleShowChapters = () => {
     setShowChapters((prev) => !prev);
   };
@@ -86,8 +91,12 @@ export const ContentRendererClient = ({
       setContentCompleted((prev) => !prev);
     }
     setLoadingMarkAs(false);
+    setMarkAsComplete({
+      isValid : true,
+      path : currentPath,
+      isCompleted : contentCompleted
+    })
   };
-
   return (
     <div className="flex gap-2 items-start flex-col lg:flex-row">
       <div className="flex-1 w-full">
@@ -130,7 +139,8 @@ export const ContentRendererClient = ({
               disabled={loadingMarkAs}
               onClick={handleMarkCompleted}
             >
-              {contentCompleted ? 'Mark as Incomplete' : 'Mark as completed'}
+              {markAsComplete.isValid && markAsComplete?.path === currentPath ? (markAsComplete?.isCompleted ? "Mark as Incomplete" : "Mark as completed") : (contentCompleted ? "Mark as Incomplete" : "Mark as completed")}
+              {/* {contentCompleted ? 'Mark as Incomplete' : 'Mark as completed'} */}
             </button>
           </div>
 

--- a/src/store/atoms/markAsComplete.ts
+++ b/src/store/atoms/markAsComplete.ts
@@ -1,0 +1,12 @@
+import {atom} from "recoil";
+
+interface markAsCompleteParams {
+    isValid : boolean
+    path? : string,
+    isCompleted? : boolean
+}
+
+export const markAsCompleteAtom = atom<markAsCompleteParams>({
+    key : "markAsCompleteAtom",
+    default : {isValid : false}
+})


### PR DESCRIPTION
Hi @hkirat , to solve this issue I observed that whenever a user is changing content then the sidebar reload data from backend and the checkbox is checked according to completed or not but the problem is only when a user is on the same page and tried to check or click on markascompleted then it could not see the changes in the sidebar and the main content screen accordingly. If sidebar again reloads the data then it will show the correct checked status.

My Approach
I created a atom for this, if any user is changing checkbox then this atom will hold its value and will reflect on the right side and vice versa. As user changes content page, sidebar again gets data from backend and the role of atom is complete.

