### PR TITLE
fix: Fixed ESLint styling rules overriding Prettier styling rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,9 +68,7 @@ rules:
   # stylistic errors
   no-spaced-func: 2
   semi-spacing: 2
-  quotes: [2, 'single']
   key-spacing: [2, { beforeColon: false, afterColon: true }]
-  indent: [2, 2]
   no-lonely-if: 2
   no-floating-decimal: 2
   brace-style: [2, 1tbs, { allowSingleLine: true }]


### PR DESCRIPTION
# Summary

This fixes the minor issue where ESLint's styling rules were overwriting the Prettier styling rules. Videos below showcase an example.

This PR is part of the Turborepo monorepo migration mentioned in #234.

EDIT: Comment below in this PR ([here](https://github.com/code100x/cms/pull/244#issuecomment-2006243552)) showcases an example of the conflicting styling rules caused before this PR.

# Changes

- [x] Removed 2 of ESLint's conflicting styling rules

# Showcase

## Before Changes

👇 Shows how the `lint:fix` script overrides changes done by `format:fix`

https://github.com/code100x/cms/assets/45622345/71cfdeb2-8e62-450a-8d5a-da72d12576d4

## After Changes

👇 ESLint (`lint:fix`) no longer conflicts with Prettier's (`format:fix`) styling changes now

https://github.com/code100x/cms/assets/45622345/ea8b2486-8556-4804-baf4-5acadb1b93f6