### PR TITLE
Resolves #216 Inconsistent Mark as Complete, checkboxes and Percentage of Video Completed

### DIFF
--- a/src/components/FolderView.tsx
+++ b/src/components/FolderView.tsx
@@ -1,6 +1,9 @@
 'use client';
 import { useRouter } from 'next/navigation';
 import { ContentCard } from './ContentCard';
+import { useRecoilValue } from 'recoil';
+import { videoCompletionAtom } from '@/store/atoms/videoCompletion';
+import { getFolderContentCompleted } from '@/lib/utils';
 
 export const FolderView = ({
   courseContent,
@@ -32,24 +35,33 @@ export const FolderView = ({
     updatedRoute += `/${rest[i]}`;
   }
   // why? because we have to reset the segments or they will be visible always after a video
-
+  const videoCompletion = useRecoilValue(videoCompletionAtom);
   return (
     <div>
       <div></div>
       <div className="max-w-screen-xl justify-between mx-auto p-4 cursor-pointer grid grid-cols-1 gap-5 md:grid-cols-3">
-        {courseContent.map((content) => (
-          <ContentCard
-            type={content.type}
-            key={content.id}
-            title={content.title}
-            image={content.image || ''}
-            onClick={() => {
-              router.push(`${updatedRoute}/${content.id}`);
-            }}
-            markAsCompleted={content.markAsCompleted}
-            percentComplete={content.percentComplete}
-          />
-        ))}
+        {courseContent.map((content) => {
+          let percent = null;
+          let isCompleted = false;
+          if (content.type === 'folder') {
+            percent = getFolderContentCompleted(videoCompletion , content.id);
+          } else if (content.type === 'video') {
+            isCompleted = videoCompletion.find((item) => item.id === content.id)?.isCompleted || false;
+          }
+          return (
+            <ContentCard
+              type={content.type}
+              key={content.id}
+              title={content.title}
+              image={content.image || ''}
+              onClick={() => {
+                router.push(`${updatedRoute}/${content.id}`);
+              }}
+              markAsCompleted={isCompleted}
+              percentComplete={percent}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { CommentFilter, QueryParams } from '@/actions/types';
+import { Folder } from '@/db/course';
 import { CommentType, Prisma } from '@prisma/client';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
@@ -10,6 +11,40 @@ export function cn(...inputs: ClassValue[]) {
 
 export interface VideoJsPlayer {
   eme: () => void;
+}
+
+export const convertToVideoCompletionData = (currentCourse: Folder[]): VideoCompletionData[] => {
+  const videoCompletionData: VideoCompletionData[] = [];
+
+  for (const folder of currentCourse) {
+    for (const child of folder?.children ?? []) {
+      if (child?.type === 'video') {
+        const { id, parentId, videoProgress } = child;
+        const isCompleted = videoProgress?.markAsCompleted ?? false;
+        videoCompletionData.push({ id, parentId, isCompleted });
+      }
+    }
+  }
+
+  return videoCompletionData;
+};
+
+export const getFolderContentCompleted = (videoCompletion : VideoCompletionData[], contentId : number) => {
+  const folderItems = videoCompletion.filter(item => item.parentId === contentId);
+  const totalContentInside = folderItems.length;
+  const totalCompleted = folderItems.filter(item => item.isCompleted).length;
+
+  if (totalContentInside === 0) {
+    return 0; 
+  }
+  
+  return Math.round((totalCompleted / totalContentInside) * 100);
+};
+
+export interface VideoCompletionData {
+  id : number;
+  parentId : number | null;
+  isCompleted : boolean | undefined;
 }
 
 export interface Segment {

--- a/src/store/atoms/videoCompletion.ts
+++ b/src/store/atoms/videoCompletion.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { VideoCompletionData } from '@/lib/utils';
+
+export const videoCompletionAtom = atom<VideoCompletionData[]>({
+  key: 'videoCompletionAtom',
+  default: []
+});


### PR DESCRIPTION
#216 
Hi @hkirat 
My Approach to solve this issue 

I have created an atom, which will be storing the completed status of all the contents present in the course. It will be in this form 
[ 
{id : 2 ,
   parentId : 1,
   isCompleted : false},
{
 id : 3,
 parentId : 1,
 isCompleted : true
}]

I can't use server function in client side so I can't use selectors here to fetch the data. So, I am initialising this atoms value using SideBar Component, whenever Sidebar is mounted, it will initialise the atom's value.

The Percentage completed shown on the folders is also handled, specifically parentId is used to calculate all children and the children which have completed the video. In this way I have tacked the percentage state also

In the ContentRendererClient where markAsComplete was written, I have shifted it to a new component just to avoid Re-renders of the video player otherwise, video was flickering was state was changing.




https://github.com/code100x/cms/assets/40340661/dfba6e20-2583-43be-bd0d-a8135bb244fc



This is a collaborative effort of me and @devsargam 