### PR TITLE
fix: video refreshes after clicking on Mark as Complete/Incomplete

### DIFF
--- a/src/components/admin/ContentRendererClient.tsx
+++ b/src/components/admin/ContentRendererClient.tsx
@@ -3,7 +3,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 // import { QualitySelector } from '../QualitySelector';
 import { VideoPlayerSegment } from '@/components/VideoPlayerSegment';
 import VideoContentChapters from '../VideoContentChapters';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { handleMarkAsCompleted } from '@/lib/utils';
 
 export const ContentRendererClient = ({
@@ -47,31 +47,28 @@ export const ContentRendererClient = ({
   }
 
   const mpdUrl = metadata?.[quality || '1080'] || '';
-  let source = {};
 
-  if (mpdUrl.endsWith('.mpd')) {
-    //@ts-ignore
-    source = {
-      src: mpdUrl,
-      type: 'application/dash+xml',
-      keySystems: {
-        'com.widevine.alpha':
-          'https://widevine-dash.ezdrm.com/proxy?pX=288FF5&user_id=MTAwMA==',
-      },
-    };
-  } else if (mpdUrl.endsWith('.m3u8')) {
-    //@ts-ignore
-    source = {
-      src: mpdUrl,
-      type: 'application/x-mpegURL',
-    };
-  } else {
-    //@ts-ignore
-    source = {
+  const source = useMemo(() => {
+    if (mpdUrl.endsWith('.mpd')) {
+      return {
+        src: mpdUrl,
+        type: 'application/dash+xml',
+        keySystems: {
+          'com.widevine.alpha':
+            'https://widevine-dash.ezdrm.com/proxy?pX=288FF5&user_id=MTAwMA==',
+        },
+      };
+    } else if (mpdUrl.endsWith('.m3u8')) {
+      return {
+        src: mpdUrl,
+        type: 'application/x-mpegURL',
+      };
+    } 
+    return {
       src: mpdUrl,
       type: 'video/mp4',
     };
-  }
+  }, [mpdUrl]);
 
   const toggleShowChapters = () => {
     setShowChapters((prev) => !prev);


### PR DESCRIPTION
### PR Fixes:
- Currently, the video refreshes when we click on `Mark as Complete/Incomplete` button.

Solution:
- The problem occurred because the `source` was updated repeatedly with state changes. I used useMemo() to cache it and now the `source` gets updated only when mpdUrl updates. And hence, the video doesn't get reloaded when clicking `Mark as Complete/Incomplete`

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
