### PR TITLE
Feat : Introducing Breadcrumbs for Enhanced Course Navigation and better UX.

### DIFF
--- a/src/components/BreadCrumbComponent.tsx
+++ b/src/components/BreadCrumbComponent.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Folder } from '@/db/course';
+import Link from 'next/link';
+import { useMemo } from 'react';
+
+export default function BreadCrumbComponent({
+  rest,
+  course,
+  fullCourseContent,
+  courseContent,
+  contentType,
+}: {
+  fullCourseContent: Folder[];
+  rest: string[];
+  course: any;
+  contentType: any;
+  courseContent: any;
+}) {
+  const findChildContent = (contents: any, childId: any) => {
+    for (const content of contents) {
+      if (content.id === childId) {
+        return content;
+      } else if (content.children && content.children.length > 0) {
+        const childContent: any = findChildContent(content.children, childId);
+        if (childContent) {
+          return childContent;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  const generateBreadcrumbs = useMemo(() => {
+    const breadcrumbs = [];
+
+    for (let i = 0; i < rest.length; i++) {
+      const childId = parseInt(rest[i], 10);
+
+      const childContent = findChildContent(fullCourseContent, childId);
+
+      if (childContent) {
+        breadcrumbs.push(childContent);
+      }
+    }
+
+    // if (courseContent.length > 0 && contentType !== 'folder') {
+    //     // breadcrumbs.push(courseContent[0]);
+    //     // console.log("courseContent[0] : ", courseContent[0]);
+    // }
+
+    return breadcrumbs;
+  }, [rest, fullCourseContent, courseContent, contentType]);
+
+  return (
+    <>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <Link href={'/'}>
+              <BreadcrumbLink>100xdevs</BreadcrumbLink>
+            </Link>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            {generateBreadcrumbs.length > 0 ? (
+              <Link href={`/courses/${course.id}`}>
+                <BreadcrumbLink>{course.title}</BreadcrumbLink>
+              </Link>
+            ) : (
+              <BreadcrumbPage>{course.title}</BreadcrumbPage>
+            )}
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          {generateBreadcrumbs.map((breadcrumb, index, array) => {
+            const indexofBreadCrumbId = rest.indexOf(breadcrumb.id.toString());
+            let finalRouteArray: any[] = [];
+            if (indexofBreadCrumbId !== -1) {
+              finalRouteArray = rest.slice(0, indexofBreadCrumbId + 1);
+            } else {
+              finalRouteArray = [...rest];
+            }
+            return (
+              <>
+                {index !== array.length - 1 ? (
+                  <>
+                    <BreadcrumbItem>
+                      <Link
+                        href={`/courses/${course.id}/${finalRouteArray.join('/')}`}
+                      >
+                        <BreadcrumbLink className="font-semibold">
+                          {breadcrumb?.title}
+                        </BreadcrumbLink>
+                      </Link>
+                    </BreadcrumbItem>
+                    {/* <BreadcrumbSeparator /> */}
+                    {index + 1 < array.length && <BreadcrumbSeparator />}
+                  </>
+                ) : (
+                  <BreadcrumbItem>
+                    <BreadcrumbPage className="font-semibold">
+                      {breadcrumb.title}
+                    </BreadcrumbPage>
+                  </BreadcrumbItem>
+                )}
+              </>
+            );
+          })}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </>
+  );
+}

--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -6,6 +6,7 @@ import { NotionRenderer } from './NotionRenderer';
 import { getFolderPercentCompleted } from '@/lib/utils';
 import Comments from './comment/Comments';
 import { QueryParams } from '@/actions/types';
+import BreadCrumbComponent from './BreadCrumbComponent';
 
 export const CourseView = ({
   rest,
@@ -30,9 +31,20 @@ export const CourseView = ({
     <div className="flex h-full">
       <Sidebar fullCourseContent={fullCourseContent} courseId={course.id} />
       <div className="grow p-2 overflow-y-auto no-scrollbar">
+        <div className=" min-h-[2.5rem] max-h-fit mb-2 flex items-center px-4">
+          <BreadCrumbComponent
+            course={course}
+            contentType={contentType}
+            courseContent={courseContent}
+            fullCourseContent={fullCourseContent}
+            rest={rest}
+          />
+        </div>
+
         {contentType === 'notion' ? (
           <NotionRenderer id={courseContent[0]?.id} />
         ) : null}
+
         {contentType === 'video' ? (
           <ContentRenderer
             nextContent={nextContent}

--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -159,7 +159,7 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
             player.volume(0);
           }
           event.stopPropagation();
-          break; 
+          break;
         case 'KeyK': // 'K' key for play/pause toggle
           if (player.paused()) {
             player.play();
@@ -169,11 +169,15 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
           event.stopPropagation();
           break;
         case 'KeyJ': // 'J' key for seeking backward 10 seconds multiplied by the playback rate
-          player.currentTime(player.currentTime() - (10 * player.playbackRate()));
+          player.currentTime(
+            player.currentTime() - 10 * player.playbackRate(),
+          );
           event.stopPropagation();
           break;
         case 'KeyL': // 'L' key for seeking forward 10 seconds multiplied by the playback rate
-          player.currentTime(player.currentTime() + (10 * player.playbackRate()));
+          player.currentTime(
+            player.currentTime() + 10 * player.playbackRate(),
+          );
           event.stopPropagation();
           break;
         }

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<'nav'> & {
+    separator?: React.ReactNode;
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
+Breadcrumb.displayName = 'Breadcrumb';
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<'ol'>
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
+      className,
+    )}
+    {...props}
+  />
+));
+BreadcrumbList.displayName = 'BreadcrumbList';
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<'li'>
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn('inline-flex items-center gap-1.5', className)}
+    {...props}
+  />
+));
+BreadcrumbItem.displayName = 'BreadcrumbItem';
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<'a'> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn('transition-colors hover:text-foreground', className)}
+      {...props}
+    />
+  );
+});
+BreadcrumbLink.displayName = 'BreadcrumbLink';
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<'span'>
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn('font-normal text-foreground', className)}
+    {...props}
+  />
+));
+BreadcrumbPage.displayName = 'BreadcrumbPage';
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'li'>) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn('[&>svg]:size-3.5', className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+);
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+);
+BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis';
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};


### PR DESCRIPTION
Closes #282 : **Dynamic Breadcrumbs**

This PR adds breadcrumbs , which will show up above the course content. These breadcrumbs will change as users move around, showing exactly where they are in the course. Making it easy to see which part of the course you're in and navigate between sections by clicking, even if the sidebar is closed, for a better user experience.

Below is how it looks like : 

https://github.com/code100x/cms/assets/118182376/14ee3656-bbca-49d0-b696-13b61cf247c0

- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue