### PR TITLE
[SOL]  Arrow keys don't work after toggling the Fullscreen unless clicked on the video again. #262

### DIFF
--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -159,7 +159,7 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
             player.volume(0);
           }
           event.stopPropagation();
-          break; 
+          break;
         case 'KeyK': // 'K' key for play/pause toggle
           if (player.paused()) {
             player.play();
@@ -169,11 +169,15 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
           event.stopPropagation();
           break;
         case 'KeyJ': // 'J' key for seeking backward 10 seconds multiplied by the playback rate
-          player.currentTime(player.currentTime() - (10 * player.playbackRate()));
+          player.currentTime(
+            player.currentTime() - 10 * player.playbackRate(),
+          );
           event.stopPropagation();
           break;
         case 'KeyL': // 'L' key for seeking forward 10 seconds multiplied by the playback rate
-          player.currentTime(player.currentTime() + (10 * player.playbackRate()));
+          player.currentTime(
+            player.currentTime() + 10 * player.playbackRate(),
+          );
           event.stopPropagation();
           break;
         }
@@ -293,6 +297,10 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
             if (onReady) {
               onReady(player);
             }
+          });
+          // Focus the video player when toggling fullscreen
+          player.on('fullscreenchange', () => {
+            videoElement.focus();
           });
         },
       ));


### PR DESCRIPTION
### PR Fixes:
- 1. This issue just needed to get the focus back to video after user toggle Fullscreen button.
- 2. It was quite irritating to click on the screen every time while changing tabs to control the video.


Resolves #262  

### Checklist before requesting a review
- [Y] I have performed a self-review of my code
- [Y] I assure there is no similar/duplicate pull request regarding same issue



Before Fixing the issue:

https://github.com/code100x/cms/assets/89627050/fe63294c-1227-47e4-9aeb-0023dbe4146b

After Fixing the issue:

https://github.com/code100x/cms/assets/89627050/ed0c4e82-0d1e-4d21-a69f-f87bba19483f

