### PR TITLE
fix: Keybindings Interference Between Video Player and Comments

### DIFF
--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -54,6 +54,16 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
     if (!player) {
       return;
     }
+    const activeElement = document.activeElement;
+
+        // Check if there is an active element and if it's an input or textarea
+    if (
+        activeElement &&
+        (activeElement.tagName.toLowerCase() === 'input' ||
+         activeElement.tagName.toLowerCase() === 'textarea')
+        ) {
+          return; // Do nothing if the active element is an input or textarea
+        }
     let volumeSetTimeout: ReturnType<typeof setInterval> | null = null;
     const handleKeyPress = (event: any) => {
       const isShiftPressed = event.shiftKey;
@@ -115,16 +125,7 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
       } else if (event.code === 'KeyT') {
         player.playbackRate(2);
       } else {
-        const activeElement = document.activeElement;
-
-        // Check if there is an active element and if it's an input or textarea
-        if (
-          activeElement &&
-          (activeElement.tagName.toLowerCase() === 'input' ||
-            activeElement.tagName.toLowerCase() === 'textarea')
-        ) {
-          return; // Do nothing if the active element is an input or textarea
-        }
+        
         switch (event.code) {
         case 'Space': // Space bar for play/pause
           if (player.paused()) {


### PR DESCRIPTION
### PR Fixes:
- 1 Keybindings Interference Between Video Player and Comments

Resolves #364 

### Description:
There is an issue where keybindings for navigating within the video player interfere with the functionality of the comments section. Specifically, the keybindings <, >, T, Shift+Up, and Shift+Down are conflicting with the video player's controls when the focus is on the comments textarea.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

### Video demo


https://github.com/code100x/cms/assets/36275192/33f92059-df89-4051-832b-4f61e3090ee7

