### PR TITLE
Fix: Keybindings Interference Between Video Player and Comments

### DIFF
--- a/src/components/comment/CommentInputForm.tsx
+++ b/src/components/comment/CommentInputForm.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button } from '../ui/button';
 import { useAction } from '@/hooks/useAction';
 import { createMessage } from '@/actions/comment';
@@ -16,6 +16,7 @@ const CommentInputForm = ({
 }) => {
   const currentPath = usePathname();
   const formRef = React.useRef<HTMLFormElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const { execute, fieldErrors } = useAction(createMessage, {
     onSuccess: () => {
       toast('Comment added');
@@ -38,9 +39,22 @@ const CommentInputForm = ({
       currentPath,
     });
   };
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Prevent shortcuts from affecting video when typing in the textarea
+        event.stopPropagation();
+    };
+
+    textareaRef.current?.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      textareaRef.current?.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
   return (
     <form className="grid gap-4" onSubmit={handleFormSubmit} ref={formRef}>
       <textarea
+        ref={textareaRef}
         id="content"
         name="content"
         className="min-h-[50px] rounded-md dark:bg-gray-800 border-2 text-muted-foreground p-2 "


### PR DESCRIPTION
### PR Fixes:
- Fixing the issue of keybindings interference between the video player and comments.

Resolves #364 

### Description:
This PR addresses an issue where keyboard shortcuts used in the comment textarea were affecting the video player's behavior. The problem occurred when certain keys, such as `<` or `>`, were pressed while typing comments, causing unintended effects on the video playback speed.

To resolve this issue, I added event handling to prevent the propagation of keyboard events when typing in the comment textarea. 

This change ensures that keyboard shortcuts are properly isolated to the comment input area, providing a smoother user experience without interfering with the video playback.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding the same issue


https://github.com/code100x/cms/assets/111479342/f526a7cd-b23a-4619-ab6f-086e913751d5

