### PR TITLE
hit checkUserEmailForPurchase in refreshDB only in prod

### DIFF
--- a/src/actions/refresh-db/index.ts
+++ b/src/actions/refresh-db/index.ts
@@ -24,6 +24,10 @@ export const refreshDb: RefreshDbFn = async () => {
     };
   }
 
+  if (process.env.LOCAL_CMS_PROVIDER) {
+    return { error: false, message: 'Refetched Courses' };
+  }
+
   // Only allow user to refetch every minute
   if (Cache.getInstance().get('rate-limit', [email])) {
     return {
@@ -51,12 +55,11 @@ export const refreshDb: RefreshDbFn = async () => {
     .filter((x) => !x.openToEveryone)
     .map(async (course) => {
       const courseId = course.appxCourseId.toString();
-      if (!process.env.LOCAL_CMS_PROVIDER) {
+      
         const data = await checkUserEmailForPurchase(email, courseId);
 
       if (data.data === '1') {
         responses.push(course);
-      }
       }
     });
 

--- a/src/actions/refresh-db/index.ts
+++ b/src/actions/refresh-db/index.ts
@@ -51,10 +51,12 @@ export const refreshDb: RefreshDbFn = async () => {
     .filter((x) => !x.openToEveryone)
     .map(async (course) => {
       const courseId = course.appxCourseId.toString();
-      const data = await checkUserEmailForPurchase(email, courseId);
+      if (!process.env.LOCAL_CMS_PROVIDER) {
+        const data = await checkUserEmailForPurchase(email, courseId);
 
       if (data.data === '1') {
         responses.push(course);
+      }
       }
     });
 


### PR DESCRIPTION
### PR Fixes:

- 1. Earlier, we were hitting checkUserEmailForPurchase in refresDb in both local and prod
- 2. Since in local we don't have APPX Creds, we now only hit it in production.

Resolves #402 

### Screencast (Before fix)
[Screencast from 14-04-24 11:47:05 AM IST.webm](https://github.com/code100x/cms/assets/130341088/91966eb1-c308-4459-8cd4-2f0ff38a5cb6)

### Screencast (After fix)
[Screencast from 14-04-24 11:48:13 AM IST.webm](https://github.com/code100x/cms/assets/130341088/bc04ee74-f5ff-4973-8a42-320e08a5cd8a)

### Checklist before requesting a review
- I have performed a self-review of my code
- I assure there is no similar/duplicate pull request regarding same issue

