### PR TITLE
Bug/#496

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,11 +14,9 @@ import { sidebarOpen as sidebarOpenAtom } from '@/store/atoms/sidebar';
 import { useEffect, useState } from 'react';
 import { handleMarkAsCompleted } from '@/lib/utils';
 import BookmarkButton from './bookmark/BookmarkButton';
+import { fullCourseContentAtom } from '@/store/atoms';
 
-const fullCourseContentAtom = atom({
-  key: 'full/course/content/atom/state/sidebar',
-  default: [] as Folder[],
-});
+
 
 export function Sidebar({
   courseId,

--- a/src/store/atoms/courses.ts
+++ b/src/store/atoms/courses.ts
@@ -1,3 +1,4 @@
+import { Folder } from '@/db/course';
 import axios from 'axios';
 import { atom, selector } from 'recoil';
 
@@ -25,4 +26,9 @@ const coursesSelector = selector({
 export const coursesAtom = atom<Course[]>({
   key: 'coursesAtom',
   default: coursesSelector,
+});
+
+export const fullCourseContentAtom = atom({
+  key: 'full/course/content/atom/state/sidebar',
+  default: [] as Folder[],
 });


### PR DESCRIPTION
### PR Fixes:
- Fixes Bug #496 
- Makes a global atom (recoil state for the side-bar component and stores the check updation state)

### Approach 
- Earlier the state was only stored in micro level in the check state so when the component is unmounted the state returns to global level (previous state for checks or course).
- Implemented Recoil State for each course to manage a global state store for the side-bar component and when a video (children) is checked it will update its state in the store and rerender the component .  

Resolves #496  

### Checklist before requesting a review
- [ ✓] I have performed a self-review of my code
- [ ✓] I assure there is no similar/duplicate pull request regarding same issue
