### PR TITLE
Show course number for multiple courses in search results for a video

### DIFF
--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -83,13 +83,25 @@ const SearchBar = ({ onCardClick }: { onCardClick?: () => void }) => {
     } else if (!searchedVideos || searchedVideos.length === 0) {
       return <VideoSearchInfo text="No videos found" />;
     }
-    return searchedVideos.map((video) => (
-      <VideoSearchCard
-        key={video.id}
-        video={video}
-        onCardClick={handleCardClick}
-      />
-    ));
+    return searchedVideos.map((video: TSearchedVideos) => {
+      const { id: videoId, parentId, parent, title } = video;
+      if (parentId && parent) {
+        const courses = parent.courses;
+        return courses.map((course) => {
+          const { courseId } = course;
+          return (
+            <VideoSearchCard
+              key={videoId}
+              videoId={videoId}
+              parentId={parentId}
+              courseId={courseId}
+              videoTitle={title}
+              onCardClick={handleCardClick}
+            />
+          );
+        });
+      }
+    });
   };
 
   return (

--- a/src/components/search/VideoSearchCard.tsx
+++ b/src/components/search/VideoSearchCard.tsx
@@ -1,31 +1,34 @@
-import { TSearchedVideos } from '@/app/api/search/route';
 import { PlayCircleIcon } from 'lucide-react';
 import React from 'react';
 
 const VideoSearchCard = ({
-  video,
+  videoId,
+  parentId,
+  courseId,
+  videoTitle,
   onCardClick,
 }: {
-  video: TSearchedVideos;
+  videoId: number;
+  parentId: number;
+  courseId: number;
+  videoTitle: string;
   onCardClick: (videoUrl: string) => void;
 }) => {
-  const { id: videoId, parentId, parent } = video;
-
-  if (parentId && parent) {
-    const courseId = parent.courses[0].courseId;
-    const videoUrl = `/courses/${courseId}/${parentId}/${videoId}`;
-    return (
-      <div
-        className="px-3 py-2 hover:bg-gray-200 hover:dark:bg-gray-700 cursor-pointer flex items-center gap-3"
-        onClick={() => onCardClick(videoUrl)}
-      >
-        <div className="min-w-content">
-          <PlayCircleIcon className="w-4 h-4" />
-        </div>
-        <span className="w-4/5">{video.title}</span>
+  const videoUrl = `/courses/${courseId}/${parentId}/${videoId}`;
+  return (
+    <div
+      className="px-3 py-2 hover:bg-gray-200 hover:dark:bg-gray-700 cursor-pointer flex items-center gap-3"
+      onClick={() => onCardClick(videoUrl)}
+    >
+      <div className="min-w-content">
+        <PlayCircleIcon className="w-4 h-4" />
       </div>
-    );
-  }
+      {/* // NOTE: Ideally course name should be showed instead of course Id(?) */}
+      <span className="w-4/5">
+        Course: {courseId} - {videoTitle}
+      </span>
+    </div>
+  );
 };
 
 export default VideoSearchCard;


### PR DESCRIPTION
### PR Fixes:
There are a couple of fixes need here I believe (might be wrong - new here 😄):
1. A user has brought multiple courses and we need to render the course name or number to show that the video exists in two courses (Please suggest alternative solutions if you have in mind, this was the easiest I could think of to get started with)
2. A user has brought only one course but the video name is the same across courses.

The current PR state: 
- [X] Solves for 1 where the course number will be displayed as the same video name can exist across multiple courses.
- [ ] To solve for 2, search results should only contain videos the user has access to.

Resolves #499 

### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I assure you there is no similar/duplicate pull request regarding the same issue
