### PR TITLE
Search recommendation redirect fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ Read our [contribution guidelines](./CONTRIBUTING.md) for more details.
 <a href="https://github.com/code100x/cms/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=code100x/cms&max=400&columns=20" />
 </a>
+

--- a/README.md
+++ b/README.md
@@ -108,4 +108,3 @@ Read our [contribution guidelines](./CONTRIBUTING.md) for more details.
 <a href="https://github.com/code100x/cms/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=code100x/cms&max=400&columns=20" />
 </a>
-

--- a/src/components/search/VideoSearchCard.tsx
+++ b/src/components/search/VideoSearchCard.tsx
@@ -1,6 +1,17 @@
 import { TSearchedVideos } from '@/app/api/search/route';
+import { CourseContent } from '@prisma/client';
 import { PlayCircleIcon } from 'lucide-react';
 import React from 'react';
+//Hypothesis needs to be tested: find the max out of all the course id(s)
+const getCourseId = (courses: CourseContent[]): number => {
+  let result = Number.MIN_SAFE_INTEGER;
+  for (const course of courses) {
+    if (course.courseId > result) {
+      result = course.courseId;
+    }
+  }
+  return result;
+};
 
 const VideoSearchCard = ({
   video,
@@ -12,7 +23,7 @@ const VideoSearchCard = ({
   const { id: videoId, parentId, parent } = video;
 
   if (parentId && parent) {
-    const courseId = parent.courses[0].courseId;
+    const courseId = getCourseId(parent.courses);
     const videoUrl = `/courses/${courseId}/${parentId}/${videoId}`;
     return (
       <div


### PR DESCRIPTION
[NOTE]: After thorough testing via direct inspection of production API responses, it was observed that the search recommendation feature might encounter issues if `parent.courses[0].courseId` is chosen as the courseId in the URL. However, upon utilizing the maximum value of courseId, the redirection functions correctly. Hence, this PR addresses the concern.

### PR Enhancements:
- Resolves an issue where the application crashes in certain Search Result scenarios, particularly those involving multiple `parent.courses`.

Fixes #478 

### Pre-Review Checklist:
- [x] I have conducted a comprehensive self-review of my code changes.
- [x] I have ensured there are no similar or duplicate pull requests addressing the same issue.
