### PR TITLE
fix: #515 add text colour to time duration

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -49,7 +49,7 @@ export const ContentCard = ({
         </div>
       )}
       {type === 'video' && (
-        <div className=" absolute bottom-12 right-2 z-10 bg-zinc-900 p-1 px-2 rounded-md font-semibold text-blue-900g">
+        <div className=" absolute bottom-12 right-2 z-10  text-white bg-zinc-900 p-1 px-2 rounded-md font-semibold text-blue-900g">
           {contentDuration && formatTime(contentDuration)}
         </div>
       )}


### PR DESCRIPTION
### PR Fixes:
- Fixed the issue  by making text color of time duration white

Resolves #515  

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
<img width="400" alt="Screenshot 2024-05-02 at 12 17 58 AM" src="https://github.com/code100x/cms/assets/121631721/8fa00491-55dd-42f7-9950-fb26b219075c">
