### PR TITLE
Fixed the Sidebar messing up layout on mobile view

### DIFF
--- a/src/app/courses/[courseId]/layout.tsx
+++ b/src/app/courses/[courseId]/layout.tsx
@@ -51,7 +51,7 @@ const Layout = async ({
   );
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-full relative">
       <Sidebar fullCourseContent={fullCourseContent} courseId={courseId[0]} />
       <div className="grow p-2 overflow-y-auto no-scrollbar">{children}</div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -159,7 +159,7 @@ export function Sidebar({
   }
 
   return (
-    <div className="overflow-y-scroll h-sidebar w-[300px] min-w-[300px] bg-gray-50 dark:bg-gray-800 cursor-pointer sticky top-[64px] self-start w-84">
+    <div className="overflow-y-scroll sm:h-sidebar w-[300px] min-w-[300px] bg-gray-50 dark:bg-gray-800 cursor-pointer top-[64px] self-start w-84 h-screen z-50 absolute sm:sticky">
       <div className="flex">
         {/* <ToggleButton
             onClick={() => {


### PR DESCRIPTION
### PR Fixes:
- Previously, the sidebar layout was not properly responsive, resulting in overlapping or misaligned content on smaller screens.
- To address this, we set a fixed width for the sidebar and adjusted its positioning accordingly.

Resolves #607 

### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I assure there is no similar/duplicate pull request regarding same issue
