### PR TITLE
Auto seeding video duration to database without manual intervention 

### DIFF
--- a/src/app/api/video/route.ts
+++ b/src/app/api/video/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import db from '@/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export async function PUT(req: NextRequest) {
+  const { contentId, duration } = await req.json();
+  const session = await getServerSession(authOptions);
+  if (!session || !session?.user) {
+    return NextResponse.json(
+      { message: 'Authentication Failed' },
+      { status: 401 },
+    );
+  }
+  try {
+    await db.videoMetadata.update({
+      where: { contentId },
+      data: { duration },
+    });
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ success: false }, { status: 400 });
+  }
+}

--- a/src/components/VideoPlayerSegment.tsx
+++ b/src/components/VideoPlayerSegment.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { FunctionComponent, useRef } from 'react';
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { VideoPlayer } from '@/components/VideoPlayer2';
 import {
   createSegmentMarkersWithoutDuration,
@@ -21,6 +21,7 @@ interface VideoProps {
   setQuality: React.Dispatch<React.SetStateAction<string>>;
   thumbnails: Thumbnail[];
   segments: Segment[];
+  duration: number;
   subtitles: string;
   videoJsOptions: any;
   contentId: number;
@@ -30,12 +31,14 @@ interface VideoProps {
 export const VideoPlayerSegment: FunctionComponent<VideoProps> = ({
   setQuality,
   contentId,
+  duration,
   subtitles,
   segments,
   videoJsOptions,
   onVideoEnd,
 }) => {
   const playerRef = useRef<Player | null>(null);
+  const [currentDuration, setCurrentDuration] = useState(0);
 
   const thumbnailPreviewRef = useRef<HTMLDivElement>(null);
 
@@ -84,9 +87,34 @@ export const VideoPlayerSegment: FunctionComponent<VideoProps> = ({
   const handlePlayerReady = async (player: Player) => {
     playerRef.current = player;
 
+    setCurrentDuration(player.cache_.duration);
     createSegmentMarkersWithoutDuration(player, segments);
     overrideUpdateTime(player);
   };
+
+  async function addVideoDuration() {
+    const newDuration = +currentDuration.toFixed(0);
+    await fetch('/api/video', {
+      method: 'PUT',
+
+      body: JSON.stringify({
+        contentId,
+        duration: newDuration,
+      }),
+
+      headers: {
+        'Content-type': 'application/json',
+      },
+    });
+  }
+
+  useEffect(() => {
+    if (currentDuration) {
+      if (duration !== +currentDuration.toFixed(0)) {
+        addVideoDuration();
+      }
+    }
+  }, [currentDuration]);
 
   return (
     <div className="mb-6">

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -39,6 +39,7 @@ export const getMetadata = async (contentId: number) => {
     slides: metadata['slides'],
     //@ts-ignore
     segments: metadata['segments'],
+    duration: metadata['duration'],
   };
   return {
     //@ts-ignore

--- a/src/components/admin/ContentRendererClient.tsx
+++ b/src/components/admin/ContentRendererClient.tsx
@@ -96,6 +96,7 @@ export const ContentRendererClient = ({
           subtitles={metadata.subtitles}
           thumbnails={[]}
           segments={metadata?.segments || []}
+          duration={metadata.duration}
           videoJsOptions={{
             playbackrates: [0.5, 1, 1.25, 1.5, 1.75, 2],
             controls: true,


### PR DESCRIPTION
### PR Fixes:
- 1 If video duration is empty, and anyone clicks on that video, It adds video duration to the database
- 2 Video thumbnail will have proper duration

Resolves #485 

Old PR #486 #558 : Closed because of many merge conflict other problems

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

## 1> Need to seed every-time when uploading a video
## 2> Week-9 is seeded but Week-10 is not seeded
![Screenshot1](https://github.com/code100x/cms/assets/28997328/c269a008-d3ce-4dbd-a9d3-374325e69853)

![Screenshot2](https://github.com/code100x/cms/assets/28997328/fc6dcf3f-a4bf-4a3f-8134-a7d651bdbf4d)

## Approach 

[Screencast.webm](https://github.com/code100x/cms/assets/28997328/57512dc8-2bed-4465-b53b-909247fea296)
