### PR TITLE
bug on running the docker-compose up

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "autoprefixer": "^10.0.1",
-
     "eslint": "^8.56.0",
     "eslint-plugin-storybook": "^0.8.0",
     "husky": "^9.0.7",
@@ -109,6 +108,6 @@
     "prettier": "^3.2.4",
     "prisma": "^5.6.0",
     "tailwindcss": "^3.3.0",
-    "ts-node": "^10.9.2",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
There was an trailing comma, which was causing errors while running docker-compose up command, so this is just to remove it
![image](https://github.com/code100x/cms/assets/97390674/4c28e183-3ffd-4d97-81d9-78c45a04bc56)
![Screenshot from 2024-05-14 20-58-57](https://github.com/code100x/cms/assets/97390674/f2ae9988-7680-474d-b8a9-d45f86d9be3b)



### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
