### PR TITLE
Fixed video bookmarking unexpected behaviour (most of the video are shown bookmarked by default)

### DIFF
--- a/src/db/course.ts
+++ b/src/db/course.ts
@@ -174,6 +174,10 @@ export const getNextVideo = async (currentVideoId: number) => {
 };
 
 async function getAllContent() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return [];
+  }
   const value = Cache.getInstance().get('getAllContent', []);
   if (value) {
     return value;
@@ -188,7 +192,11 @@ async function getAllContent() {
           duration: true,
         },
       },
-      bookmark: true,
+      bookmark: {
+        where: {
+          userId: session?.user?.id,
+        },
+      },
     },
   });
   Cache.getInstance().set('getAllContent', [], allContent);


### PR DESCRIPTION
### PR Fixes:
- Fixed video bookmarking unexpected behaviour (most of the video are shown bookmarked by default & removing of bookmarks isn't working perfectly)

As you can see I haven't bookmarked any video but still it's shown as bookmarked.
![image](https://github.com/code100x/cms/assets/81454473/59acd5d0-3c51-49a0-b79a-50fa0b2b4959)

And if I try to remove that bookmark, it gives this error.
![image](https://github.com/code100x/cms/assets/81454473/8b4933ce-1d7f-4bba-ba47-bb0a07482776)

It was too complicated to find the bug in the first go, but eventually I found that the course content fetching doesn't have any constraints that makes sure only currently logged-in user's bookmarks are being fetched.

So I've added that constraint, that resolved this issue.

I've make sure that the issue is resolved perfectly now.

Please go through this https://github.com/code100x/cms/issues/635#issuecomment-2114674836

I've explained the issue & solution perfectly there.

Resolves #635 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding the same issue
