### PR TITLE
Fixed video mark as complete bug #654

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "autoprefixer": "^10.0.1",
-
     "eslint": "^8.56.0",
     "eslint-plugin-storybook": "^0.8.0",
     "husky": "^9.0.7",
@@ -109,6 +108,6 @@
     "prettier": "^3.2.4",
     "prisma": "^5.6.0",
     "tailwindcss": "^3.3.0",
-    "ts-node": "^10.9.2",
+    "ts-node": "^10.9.2"
   }
 }

--- a/src/app/api/course/videoProgress/markAsCompleted/route.ts
+++ b/src/app/api/course/videoProgress/markAsCompleted/route.ts
@@ -10,7 +10,7 @@ const requestBodySchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
-  const parseResult = requestBodySchema.safeParse(req.json());
+  const parseResult = requestBodySchema.safeParse(await req.json());
   if (!parseResult.success) {
     return NextResponse.json(
       { error: parseResult.error.message },

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -4,6 +4,8 @@ import PercentageComplete from './PercentageComplete';
 import { PrimaryButton } from './buttons/PrimaryButton';
 import { SecondaryButton } from './buttons/SecondaryButton';
 import { useRouter } from 'next/navigation';
+import { ChevronRight } from 'lucide-react';
+import { Button } from './ui/button';
 
 export const CourseCard = ({
   course,


### PR DESCRIPTION
This PR is raised in reponse to the **issue #654** 

Here is what all has changed
1) In the backend route handler for the _/markAsCompleted_ route  we were parsing incorrect inputs to the zod safe parse hence resulting in a status 400. 

We need to await the response and check for the inputs.

I'm attaching the screenshot of the network logs post fix 

![reference](https://github.com/code100x/cms/assets/82126119/f609859e-7cf3-4628-bca4-15e1d216dbbe)


Apart from the original issue some minor changes
1) Package.json had a minor error
2) Coursecard.tsx had some minor import issue

  