### PR TITLE
Fixed Video player on hover

### DIFF
--- a/src/components/videothumbnail.tsx
+++ b/src/components/videothumbnail.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import VideoPreview from '@/actions/videopreview/videoPreview';
-import { useEffect } from 'react';
+import videojs from 'video.js';
+import 'video.js/dist/video-js.css';
+import Player from 'video.js/dist/types/player';
 
 const VideoThumbnail = ({
   imageUrl,
@@ -11,6 +13,49 @@ const VideoThumbnail = ({
 }) => {
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [hover, setHover] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+  const videoRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<Player | null>(null);
+  const player = playerRef.current;
+
+  const source = useMemo(() => {
+    if (videoUrl?.endsWith('.mpd')) {
+      return {
+        src: videoUrl,
+        type: 'application/dash+xml',
+        keySystems: {
+          'com.widevine.alpha':
+            'https://widevine-dash.ezdrm.com/proxy?pX=288FF5&user_id=MTAwMA==',
+        },
+      };
+    } else if (videoUrl?.endsWith('.m3u8')) {
+      return {
+        src: videoUrl,
+        type: 'application/x-mpegURL',
+      };
+    }
+    return {
+      src: videoUrl,
+      type: 'video/mp4',
+    };
+  }, [videoUrl]);
+
+  const videojsOptions = {
+    autoplay: true,
+    controls: true,
+    fluid: true,
+    sources: [source],
+    muted: true,
+    disablePictureInPicture: true,
+    controlBar: {
+      children: [
+        'currentTimeDisplay',
+        'timeDivider',
+        'durationDisplay',
+        'progressControl',
+      ],
+    },
+  };
 
   useEffect(() => {
     async function fetchVideoUrl() {
@@ -20,12 +65,49 @@ const VideoThumbnail = ({
     fetchVideoUrl();
   }, [contentId]);
   const handleMouseEnter = () => {
-    setHover(true);
+    if (!timeoutRef.current) {
+      timeoutRef.current = window.setTimeout(() => {
+        setHover(true);
+      }, 700);
+    }
   };
 
   const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     setHover(false);
   };
+
+  useEffect(() => {
+    if (!playerRef.current && videoRef.current) {
+      const videoElement = document.createElement('video-js');
+      videoElement.classList.add('vjs-big-play-centered');
+
+      videoRef.current.appendChild(videoElement);
+      playerRef.current = videojs(videoElement, videojsOptions);
+    }
+  }, [videojsOptions]);
+
+  useEffect(() => {
+    if (player) {
+      const currentTime = player.currentTime();
+      player.src(videojsOptions.sources[0]);
+      player.currentTime(currentTime);
+      player.autoplay(videojsOptions.autoplay);
+    }
+  }, [videojsOptions.sources[0]]);
+
+  useEffect(() => {
+    return () => {
+      if (player && !player.isDisposed()) {
+        player.dispose();
+        playerRef.current = null;
+      }
+    };
+  }, [handleMouseLeave]);
+
   return (
     <div
       className="m max-h-[573px] max-w-[1053px]  relative"
@@ -34,10 +116,8 @@ const VideoThumbnail = ({
     >
       <div className=" w-full h-full relative">
         {hover && videoUrl ? (
-          <div className="w-full h-full">
-            <video muted autoPlay width="100%" height="100%">
-              <source src={videoUrl} type="video/mp4" />
-            </video>
+          <div data-vjs-player>
+            <div ref={videoRef} />
           </div>
         ) : (
           <img


### PR DESCRIPTION
### PR Fixes:
- 1 Added a responsive and dragable seek bar on hover while playing the video on hover.
- 2 Added the timeout so that the video loads on hover only when mouse is on the videothumbnail for a while(700 milliseconds).
- 3 Supports various file formats

### Description
-This PR uses **Video.Js** library which **is already being used** to play the video in main videoPlayer, i have tweaked it such a way that **only seekBar is visible along with the time elapsed**, and it is responsive so that the user can skim through it to check what the content is.
-I have also **added  a timeout to the hover** so that the video takes a very small fraction of time to load when the mouse is over it. This is done because in the current app.100xdevs.com site when we try to navigate the mouse pointer the hover triggers immediately resulting in too many calls.

Resolves  #480  
The issue **480 was reopened** to support various video formats, and this issue was linked to PR 651 which was closed because the code was very dependent on the new external library that was not used before.

I have fixed the above issue in this PR. Here is the demo video of the fix


https://github.com/code100x/cms/assets/115367435/f8c343dc-e1e9-4992-8db4-dd5dc0653c52

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
