### PR TITLE
feat: Add fallback to Bunny URLs if main URLs are not accessible

### DIFF
--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -105,8 +105,7 @@ export const getMetadata = async (contentId: number) => {
 
   const otherQualities = ['720', '360'];
   for (const quality of otherQualities) {
-    const urlKey = `${quality}`;
-    const isAccessible = await isUrlAccessible(mainUrls[urlKey]);
+    const isAccessible = await isUrlAccessible(mainUrls[quality]);
     if (isAccessible) {
       return mainUrls;
     }

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -36,7 +36,6 @@ export const getMetadata = async (contentId: number) => {
       contentId,
     },
   });
-
   if (!metadata) {
     return null;
   }
@@ -48,33 +47,33 @@ export const getMetadata = async (contentId: number) => {
     },
   });
 
-  // @ts-ignore
+  //@ts-ignore
   // if (metadata.migration_status === 'MIGRATED') {
   //   return {
-  //     // @ts-ignore
+  //     //@ts-ignore
   //     1080: metadata[`migrated_video_1080p_mp4_1`].replace(
   //       '100x.b-cdn.net',
   //       'cdn.100xdevs.com',
   //     ),
-  //     // @ts-ignore
+  //     //@ts-ignore
   //     720: metadata[`migrated_video_720p_mp4_1`].replace(
   //       '100x.b-cdn.net',
   //       'cdn.100xdevs.com',
   //     ),
-  //     // @ts-ignore
+  //     //@ts-ignore
   //     360: metadata[`migrated_video_360p_mp4_1`].replace(
   //       '100x.b-cdn.net',
   //       'cdn.100xdevs.com',
   //     ),
   //     subtitles: metadata['subtitles'],
-  //     // @ts-ignore
+  //     //@ts-ignore
   //     slides: metadata['slides'],
-  //     // @ts-ignore
+  //     //@ts-ignore
   //     segments: metadata['segments'],
   //   };
   // }
 
-  if (user?.bunnyProxyEnabled) {
+  if (user.bunnyProxyEnabled) {
     return {
       1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
       720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
@@ -86,24 +85,52 @@ export const getMetadata = async (contentId: number) => {
     };
   }
 
-  const mainUrls = {
-    1080: metadata[`video_1080p_mp4_${userId}`],
-    720: metadata[`video_720p_mp4_${userId}`],
-    360: metadata[`video_360p_mp4_${userId}`],
-    subtitles: metadata['subtitles'],
-    slides: metadata['slides'],
-    segments: metadata['segments'],
-  };
+  // Check the highest quality video URL (1080p) first
+  const highestQualityUrl = metadata[`video_1080p_mp4_${userId}`];
+  const isHighestQualityUrlAccessible = await isUrlAccessible(highestQualityUrl);
 
-  const isMainUrlAccessible = await Promise.all(
-    Object.values(mainUrls).map(isUrlAccessible)
-  );
-
-  if (isMainUrlAccessible.every(Boolean)) {
-    return mainUrls;
+  if (isHighestQualityUrlAccessible) {
+    // If the highest quality URL is accessible, return all main URLs
+    return {
+      1080: highestQualityUrl,
+      720: metadata[`video_720p_mp4_${userId}`],
+      360: metadata[`video_360p_mp4_${userId}`],
+      subtitles: metadata['subtitles'],
+      slides: metadata['slides'],
+      segments: metadata['segments'],
+    };
   }
 
-  // If any main URL is not accessible, return Bunny URLs
+  // If the highest quality URL is not accessible, check the 720p URL
+  const mediumQualityUrl = metadata[`video_720p_mp4_${userId}`];
+  const isMediumQualityUrlAccessible = await isUrlAccessible(mediumQualityUrl);
+
+  if (isMediumQualityUrlAccessible) {
+    // If the 720p URL is accessible, return main URLs for 720p and 360p
+    return {
+      720: mediumQualityUrl,
+      360: metadata[`video_360p_mp4_${userId}`],
+      subtitles: metadata['subtitles'],
+      slides: metadata['slides'],
+      segments: metadata['segments'],
+    };
+  }
+
+  // If the 720p URL is not accessible, check the 360p URL
+  const lowestQualityUrl = metadata[`video_360p_mp4_${userId}`];
+  const isLowestQualityUrlAccessible = await isUrlAccessible(lowestQualityUrl);
+
+  if (isLowestQualityUrlAccessible) {
+    // If the 360p URL is accessible, return the main URL for 360p
+    return {
+      360: lowestQualityUrl,
+      subtitles: metadata['subtitles'],
+      slides: metadata['slides'],
+      segments: metadata['segments'],
+    };
+  }
+
+  // If none of the main URLs are accessible, return Bunny URLs
   return {
     1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
     720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -36,43 +36,45 @@ export const getMetadata = async (contentId: number) => {
       contentId,
     },
   });
-  
+
   if (!metadata) {
     return null;
   }
-  
+
   const userId: string = (1).toString();
-   const user = await db.user.findFirst({
+  const user = await db.user.findFirst({
     where: {
-    id: session?.user?.id?.toString() || '-1',
-   },
- });
-  //@ts-ignore
+      id: session?.user?.id?.toString() || '-1',
+    },
+  });
+
+  // @ts-ignore
   // if (metadata.migration_status === 'MIGRATED') {
   //   return {
-  //     //@ts-ignore
+  //     // @ts-ignore
   //     1080: metadata[`migrated_video_1080p_mp4_1`].replace(
   //       '100x.b-cdn.net',
   //       'cdn.100xdevs.com',
   //     ),
-  //     //@ts-ignore
+  //     // @ts-ignore
   //     720: metadata[`migrated_video_720p_mp4_1`].replace(
   //       '100x.b-cdn.net',
   //       'cdn.100xdevs.com',
   //     ),
-  //     //@ts-ignore
+  //     // @ts-ignore
   //     360: metadata[`migrated_video_360p_mp4_1`].replace(
   //       '100x.b-cdn.net',
   //       'cdn.100xdevs.com',
   //     ),
   //     subtitles: metadata['subtitles'],
-  //     //@ts-ignore
+  //     // @ts-ignore
   //     slides: metadata['slides'],
-  //     //@ts-ignore
+  //     // @ts-ignore
   //     segments: metadata['segments'],
   //   };
   // }
-  if (user.bunnyProxyEnabled) {
+
+  if (user?.bunnyProxyEnabled) {
     return {
       1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
       720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -36,6 +36,7 @@ export const getMetadata = async (contentId: number) => {
       contentId,
     },
   });
+  
   if (!metadata) {
     return null;
   }

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -41,11 +41,11 @@ export const getMetadata = async (contentId: number) => {
   }
   
   const userId: string = (1).toString();
-  // const user = await db.user.findFirst({
-  //   where: {
-  //     id: session?.user?.id?.toString() || '-1',
-  //   },
-  // });
+   const user = await db.user.findFirst({
+    where: {
+    id: session?.user?.id?.toString() || '-1',
+   },
+ });
   //@ts-ignore
   // if (metadata.migration_status === 'MIGRATED') {
   //   return {

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -86,43 +86,41 @@ export const getMetadata = async (contentId: number) => {
   }
 
   const mainUrls = {
-    1080: metadata[`video_1080p_mp4_${userId}`],
-    720: metadata[`video_720p_mp4_${userId}`],
-    360: metadata[`video_360p_mp4_${userId}`],
-    subtitles: metadata['subtitles'],
-    slides: metadata['slides'],
-    segments: metadata['segments'],
-    thumbnails: metadata['thumbnail_mosiac_url'],
-  };
+  1080: metadata[`video_1080p_mp4_${userId}`],
+  720: metadata[`video_720p_mp4_${userId}`],
+  360: metadata[`video_360p_mp4_${userId}`],
+  subtitles: metadata['subtitles'],
+  slides: metadata['slides'],
+  segments: metadata['segments'],
+  thumbnails: metadata['thumbnail_mosiac_url'],
+};
 
-  const bunnyUrls = {
-    1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
-    720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
-    360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
-    subtitles: metadata['subtitles'],
-    slides: metadata['slides'],
-    segments: metadata['segments'],
-    thumbnails: metadata['thumbnail_mosiac_url'],
-  };
+const bunnyUrls = {
+  1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
+  720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
+  360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
+  subtitles: metadata['subtitles'],
+  slides: metadata['slides'],
+  segments: metadata['segments'],
+  thumbnails: metadata['thumbnail_mosiac_url'],
+};
 
-  const isHighestQualityUrlAccessible = await isUrlAccessible(mainUrls['1080']);
+const isHighestQualityUrlAccessible = await isUrlAccessible(mainUrls['1080']);
 
-  if (isHighestQualityUrlAccessible) {
+if (isHighestQualityUrlAccessible) {
+  return mainUrls;
+}
+
+const otherQualities = ['720', '360'];
+for (const quality of otherQualities) {
+  const urlKey = `${quality}`;
+  const isAccessible = await isUrlAccessible(mainUrls[urlKey]);
+  if (isAccessible) {
     return mainUrls;
   }
+}
 
-  const otherQualities = ['720', '360'];
-  for (const quality of otherQualities) {
-    const urlKey = `${quality}`;
-    const isAccessible = await isUrlAccessible(mainUrls[urlKey]);
-    if (isAccessible) {
-      return mainUrls;
-    }
-  }
-
-  // If none of the main URLs are accessible, return Bunny URLs
-  return bunnyUrls;
-};
+return bunnyUrls;
 
 export const ContentRenderer = async ({
   content,

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -73,32 +73,24 @@ export const getMetadata = async (contentId: number) => {
   //   };
   // }
 
-  if (user.bunnyProxyEnabled) {
-    return {
-      1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
-      720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
-      360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
-      subtitles: metadata['subtitles'],
-      slides: metadata['slides'],
-      segments: metadata['segments'],
-      thumbnails: metadata['thumbnail_mosiac_url'],
-    };
-  }
-
-  const mainUrls = {
-    1080: metadata[`video_1080p_mp4_${userId}`],
-    720: metadata[`video_720p_mp4_${userId}`],
-    360: metadata[`video_360p_mp4_${userId}`],
+  const bunnyUrls = {
+    1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
+    720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
+    360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
     subtitles: metadata['subtitles'],
     slides: metadata['slides'],
     segments: metadata['segments'],
     thumbnails: metadata['thumbnail_mosiac_url'],
   };
 
-  const bunnyUrls = {
-    1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
-    720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
-    360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
+  if (user.bunnyProxyEnabled) {
+    return bunnyUrls;
+  }
+
+  const mainUrls = {
+    1080: metadata[`video_1080p_mp4_${userId}`],
+    720: metadata[`video_720p_mp4_${userId}`],
+    360: metadata[`video_360p_mp4_${userId}`],
     subtitles: metadata['subtitles'],
     slides: metadata['slides'],
     segments: metadata['segments'],
@@ -120,6 +112,7 @@ export const getMetadata = async (contentId: number) => {
     }
   }
 
+  // If none of the main URLs are accessible, return Bunny URLs
   return bunnyUrls;
 };
 

--- a/src/components/admin/ContentRenderer.tsx
+++ b/src/components/admin/ContentRenderer.tsx
@@ -47,7 +47,7 @@ export const getMetadata = async (contentId: number) => {
     },
   });
 
-  //@ts-ignore
+  // //@ts-ignore
   // if (metadata.migration_status === 'MIGRATED') {
   //   return {
   //     //@ts-ignore
@@ -86,41 +86,42 @@ export const getMetadata = async (contentId: number) => {
   }
 
   const mainUrls = {
-  1080: metadata[`video_1080p_mp4_${userId}`],
-  720: metadata[`video_720p_mp4_${userId}`],
-  360: metadata[`video_360p_mp4_${userId}`],
-  subtitles: metadata['subtitles'],
-  slides: metadata['slides'],
-  segments: metadata['segments'],
-  thumbnails: metadata['thumbnail_mosiac_url'],
-};
+    1080: metadata[`video_1080p_mp4_${userId}`],
+    720: metadata[`video_720p_mp4_${userId}`],
+    360: metadata[`video_360p_mp4_${userId}`],
+    subtitles: metadata['subtitles'],
+    slides: metadata['slides'],
+    segments: metadata['segments'],
+    thumbnails: metadata['thumbnail_mosiac_url'],
+  };
 
-const bunnyUrls = {
-  1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
-  720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
-  360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
-  subtitles: metadata['subtitles'],
-  slides: metadata['slides'],
-  segments: metadata['segments'],
-  thumbnails: metadata['thumbnail_mosiac_url'],
-};
+  const bunnyUrls = {
+    1080: bunnyUrl(metadata[`video_1080p_mp4_${userId}`]),
+    720: bunnyUrl(metadata[`video_720p_mp4_${userId}`]),
+    360: bunnyUrl(metadata[`video_360p_mp4_${userId}`]),
+    subtitles: metadata['subtitles'],
+    slides: metadata['slides'],
+    segments: metadata['segments'],
+    thumbnails: metadata['thumbnail_mosiac_url'],
+  };
 
-const isHighestQualityUrlAccessible = await isUrlAccessible(mainUrls['1080']);
+  const isHighestQualityUrlAccessible = await isUrlAccessible(mainUrls['1080']);
 
-if (isHighestQualityUrlAccessible) {
-  return mainUrls;
-}
-
-const otherQualities = ['720', '360'];
-for (const quality of otherQualities) {
-  const urlKey = `${quality}`;
-  const isAccessible = await isUrlAccessible(mainUrls[urlKey]);
-  if (isAccessible) {
+  if (isHighestQualityUrlAccessible) {
     return mainUrls;
   }
-}
 
-return bunnyUrls;
+  const otherQualities = ['720', '360'];
+  for (const quality of otherQualities) {
+    const urlKey = `${quality}`;
+    const isAccessible = await isUrlAccessible(mainUrls[urlKey]);
+    if (isAccessible) {
+      return mainUrls;
+    }
+  }
+
+  return bunnyUrls;
+};
 
 export const ContentRenderer = async ({
   content,


### PR DESCRIPTION
### PR Fixes: #776 
This PR adds a new feature to the `ContentRenderer` component that checks if the main video URLs from the database are accessible or not. If any of the main URLs are not accessible, it falls back to using the Bunny URLs instead.

Changes:

1. Added a new helper function `isUrlAccessible` that makes a HEAD request to a given URL and returns a boolean indicating whether the URL is accessible or not.

2. Modified the `getMetadata` function:
   - If the `user.bunnyProxyEnabled` flag is true, it returns the Bunny URLs directly.
   - If `bunnyProxyEnabled` is false, it creates an object `mainUrls` containing the main URLs from the database.
   - It then uses `Promise.all` and the `isUrlAccessible` function to check if all the main URLs are accessible.
   - If all main URLs are accessible, it returns `mainUrls`.
   - If any of the main URLs is not accessible, it returns the Bunny URLs instead.

This change ensures that if the main video URLs are not accessible for any reason, the application falls back to using the Bunny URLs, providing a more reliable experience for users.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
