### PR TITLE
fixing word splits at the end of the comments card

### DIFF
--- a/src/components/comment/TimeCodeComment.tsx
+++ b/src/components/comment/TimeCodeComment.tsx
@@ -95,7 +95,7 @@ const TimeCodeComment: React.FC<TimeCodeCommentProps> = ({
   };
 
   return (
-    <p className="break-all">
+    <p>
       {comment.split('\n').map((line, index) => (
         <React.Fragment key={`line-${index}`}>
           {processLine(line)}


### PR DESCRIPTION
### PR Fixes:
- 1 Fixes the word split at the end of comments box.

Before : 
![image](https://github.com/code100x/cms/assets/113091818/40a3f969-3089-4186-982d-60c669ddcb2f)

After :
![image](https://github.com/code100x/cms/assets/113091818/c3a8a231-90f9-4747-8769-5daed1082311)


Resolves #801 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
