### PR TITLE
Fix drop-up menu collapse in quality selector & add toggleMenuVisiblity

### DIFF
--- a/src/components/QualitySelectorControllBar.ts
+++ b/src/components/QualitySelectorControllBar.ts
@@ -32,14 +32,15 @@ class QualitySelectorControllBar extends videojs.getComponent('Button') {
 
     const dropUpMenuElement = this.el().appendChild(dropUpMenu) as HTMLElement;
 
-    this.on('click', () => {
+    const toggleMenuVisiblity = () => {
       const isVisible = dropUpMenuElement.style.display === 'block';
       dropUpMenuElement.style.display = isVisible ? 'none' : 'block';
-    });
+    };
+
+    this.on('click', toggleMenuVisiblity);
     this.on('touchend', (e: any) => {
       e.preventDefault();
-      const isVisible = dropUpMenuElement.style.display === 'block';
-      dropUpMenuElement.style.display = isVisible ? 'none' : 'block';
+      toggleMenuVisiblity();
     });
     dropUpMenuElement.querySelectorAll('li').forEach((item) => {
       item.addEventListener('click', (e: any) => {
@@ -48,15 +49,13 @@ class QualitySelectorControllBar extends videojs.getComponent('Button') {
         if (quality !== urlParams.get('quality')) {
           changeVideoQuality(quality, player);
         }
-        dropUpMenuElement.style.display = 'none';
       });
       item.addEventListener('touchend', (e: any) => {
         const quality = e.target.getAttribute('data-quality');
+        toggleMenuVisiblity();
         if (quality) {
           changeVideoQuality(quality, player);
         }
-        dropUpMenuElement.style.display = 'none';
-        dropUpMenuElement.style.display = 'none';
       });
     });
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,14 +16,14 @@
     "incremental": true,
     "plugins": [
       {
-        "name": "next"
-      }
+        "name": "next",
+      },
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "@public/*": ["./public/*"]
-    }
+      "@public/*": ["./public/*"],
+    },
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
### Description

This PR addresses an issue with the drop-up menu in the quality selector where the menu did not collapse after selecting an option. 

### Changes

- **Improved Menu Behavior**: Updated `QualitySelectorControlBar` to handle menu visibility and quality selection.
- **DRY Principle Applied**: Added `toggleMenuVisibility` function to manage the drop-up menu’s visibility, consolidating repeated logic and adhering to the DRY (Don't Repeat Yourself) principle. This ensures that menu visibility logic is maintained in a single function, improving code clarity and maintainability.
- **Removed Redundant Code**: Eliminated unnecessary code related to menu collapsing, relying on default behaviors where applicable.

### Testing

- Clicking or touching the quality selector button should correctly toggle the menu visibility.
- Selecting a video quality should apply the selection and close the menu.

https://github.com/user-attachments/assets/57ff0e82-e892-4c39-826a-85f1ef9b3b0b