### PR TITLE
Fix: Ensure loading toast only displays when both email and password …

### DIFF
--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -24,7 +24,7 @@ const Signin = () => {
   const password = useRef('');
 
   const handleSubmit = async (e?: React.FormEvent<HTMLButtonElement>) => {
-    const loadId = toast.loading('Signing in...');
+    
     if (e) {
       e.preventDefault();
     }
@@ -34,9 +34,12 @@ const Signin = () => {
         emailReq: email.current ? false : true,
         passReq: password.current ? false : true,
       });
-      toast.dismiss(loadId);
+      
       return;
     }
+
+    const loadId = toast.loading('Signing in...');
+    
     setCheckingPassword(true);
     const res = await signIn('credentials', {
       username: email.current,


### PR DESCRIPTION
**Found this BUG and resolved it**

Another guy has tried it and someone merged it but this error still persists.

When clicking on the submit button while the email or password fields were empty on app.100xdevs.com, an infinite toast was displayed at the bottom-right corner during login.