### PR TITLE
Fixed typo : Watch History was written as Watch Hostory

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -17,7 +17,7 @@ export const menuOptions = [
   { id: 1, name: 'My Courses', Component: Library, href: '/my-courses' },
   { id: 3, name: 'Bookmarks', Component: Bookmark, href: '/bookmark' },
   { id: 4, name: 'Questions', Component: MessageSquare, href: '/question' },
-  { id: 5, name: 'Watch Hostory', Component: History, href: '/watch-history' },
+  { id: 5, name: 'Watch History', Component: History, href: '/watch-history' },
 ];
 
 export const MenuOptions = () => {


### PR DESCRIPTION
Corrected a typo on the website. The word "hostory" has been corrected to "history" for improved accuracy and readability.

### PR Fixes:
- 1
- 2

Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
