### PR TITLE
fix: Handle null duration in content card

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -198,15 +198,15 @@ export function ToggleButton({
       className="flex flex-col items-center justify-center"
     >
       <span
-        className={`h - 0.5 w - 6 - sm bg - black - all duration - 300 ease - out dark: bg - white block rounded transition ${!sidebarOpen ? 'translate-y-1 rotate-45' : '-translate-y-0.5'} `}
+        className={`h - 0.5 w 6 sm bg black all duration 300 ease out dark: white block rounded transition ${!sidebarOpen ? 'translate-y-1 rotate-45' : '-translate-y-0.5'} `}
       ></span>
       <span
-        className={`my - 0.5 h - 0.5 w - 6 - sm bg - black - all duration - 300 ease - out dark: bg - white block rounded transition ${
+        className={`my - 0.5 h w 6 sm bg black all duration 300 ease out dark: white block rounded transition ${
           !sidebarOpen ? 'opacity-0' : 'opacity-100'
         } `}
       ></span>
       <span
-        className={`h - 0.5 w - 6 - sm bg - black - all duration - 300 ease - out dark: bg - white block rounded transition ${
+        className={`h - 0.5 w 6 sm bg black all duration 300 ease out dark: white block rounded transition ${
           !sidebarOpen ? '-translate-y-1 -rotate-45' : 'translate-y-0.5'
         } `}
       ></span>

--- a/src/components/WatchHistoryClient.tsx
+++ b/src/components/WatchHistoryClient.tsx
@@ -55,6 +55,7 @@ const HistoryCard = ({
         }}
         videoProgressPercent={videoProgressPercent}
         hoverExpand={false}
+        contentDuration={videoDuration || 0}
       />
     );
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,14 +16,14 @@
     "incremental": true,
     "plugins": [
       {
-        "name": "next"
-      }
+        "name": "next",
+      },
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "@public/*": ["./public/*"]
-    }
+      "@public/*": ["./public/*"],
+    },
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
### PR Fixes:
This PR addresses a UI issue where content cards displayed incorrectly when the duration value was null.

Before:
![Screenshot 2024-08-22 230504](https://github.com/user-attachments/assets/78fc11bd-a82f-4fd4-b2f3-20428e2b9b26)

After:
![Screenshot 2024-08-22 231036](https://github.com/user-attachments/assets/ee6a923c-aeac-43fa-bbac-d332cf521bbc)


Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
