### PR TITLE
fixed the split screen issue by closing sidebar and courseViewToolbar…

### DIFF
--- a/src/components/CourseViewToolbar.tsx
+++ b/src/components/CourseViewToolbar.tsx
@@ -23,9 +23,26 @@ export const CourseViewToolbar = ({
   const [showButtonTitle, setShowButtonTitle] = useState<boolean>(true);
 
   useEffect(() => {
-    if (window.innerWidth < 500) {
-      setShowButtonTitle(false);
-    }
+    const handleResize = () => {
+      if (window.innerWidth < 500) {
+        setShowButtonTitle(false);
+      }
+      if (window.innerWidth < 900) {
+        // set sidebar open to false
+        setSidebarOpen(false);
+      }
+    };
+
+    // Initial check
+    handleResize();
+
+    // Add event listener
+    window.addEventListener('resize', handleResize);
+
+    // Clean up the event listener on component unmount
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   return (

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -27,9 +27,21 @@ export const MenuOptions = () => {
   const [expanded, setExpanded] = useState(true);
 
   useEffect(() => {
-    if (window.innerWidth < 500) {
-      setExpanded(false);
-    }
+    const handleResize = () => {
+      if (window.innerWidth < 900) {
+        setExpanded(false);
+      }
+    };
+
+    handleResize();
+
+    // Add event listener
+    window.addEventListener('resize', handleResize);
+
+    // Clean up the event listener on component unmount
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
… when screenwidth is less than 900

### PR Fixes:
- 1 Responsiveness issue when we view the webpage in a split screen was resolved using resize event listener in useEffect hook

Resolves #1094 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

Before:
![image](https://github.com/user-attachments/assets/cf426d8f-26c4-4397-a7a7-54d191113b48)

After:
![image](https://github.com/user-attachments/assets/b02ae9a0-e4cc-4153-921d-253091ee73af)
