### PR TITLE
Fix: Redirect unauthenticated users from /questions,/watch-history to…

### DIFF
--- a/src/app/(main)/(pages)/question/page.tsx
+++ b/src/app/(main)/(pages)/question/page.tsx
@@ -133,6 +133,10 @@ export default async function QuestionsPage({
     redirect('/');
   }
   const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/signin');
+    return null; // Prevent further rendering
+  }
   const sessionId = session?.user?.id;
 
   const tabType = searchParams.tabtype || TabType.mu;

--- a/src/app/(main)/(pages)/watch-history/page.tsx
+++ b/src/app/(main)/(pages)/watch-history/page.tsx
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { Content, CourseContent, VideoProgress } from '@prisma/client';
 import WatchHistoryClient from '@/components/WatchHistoryClient';
 import { Fragment } from 'react';
+import { redirect } from 'next/navigation';
 
 export type TWatchHistory = VideoProgress & {
   content: Content & {
@@ -89,6 +90,11 @@ async function getWatchHistory() {
 }
 
 export default async function WatchHistoryPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/signin');
+    return null; // Prevent further rendering
+  }
   const watchHistory = await getWatchHistory();
   const watchHistoryGroupedByDate = groupByWatchedDate(watchHistory);
 

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -133,6 +133,10 @@ export default async function Home({
     redirect('/');
   }
   const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/signin');
+    return null; // Prevent further rendering
+  }
   const sessionId = session?.user?.id;
 
   const tabType = searchParams.tabtype || TabType.mu;


### PR DESCRIPTION
**PR Fixes:**
1. Ensured that unauthenticated users are redirected to the sign-in page when attempting to access the `/questions  /questions /watch-history`,  pages.
2. Updated logic to check user session before allowing access to protected routes.

---

**Resolves:**  
#1115

https://www.loom.com/share/11b11e76356b4d6a94f62819f521fa6e
---

**Checklist before requesting a review:**
- [x] I have performed a self-review of my code.
- [ ] I assure there is no similar/duplicate pull request regarding the same issue
