### PR TITLE
Fix : Unauthenticated users can access the /questions page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,14 @@ import { withAuth } from 'next-auth/middleware';
 import { NextResponse } from 'next/server';
 
 export const config = {
-  matcher: ['/courses/:path*'],
+  matcher: [
+    '/courses/:path*',
+    '/question/:path*',
+    '/questions/:path*',
+    '/bookmark',
+    '/bookmarks',
+    '/watch-history',
+  ],
 };
 
 export default withAuth(async (req) => {


### PR DESCRIPTION
### PR Fixes:
- 1 Fixed an issue causing the website to crash with a "503 Gateway Timeout" error when users repeatedly accessed the /bookmark route or any other unprotected routes.
- 2 Implemented a redirect to the sign-in page for unauthenticated users attempting to access protected routes.

Resolves #1115  

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
