### PR TITLE
Update docker-compose.yml remove version as it is deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   app:
     build: .


### PR DESCRIPTION
Remove the version tag from the docker-compose.yml file as it raises a warning as it was deprecated as mentioned [here](https://github.com/docker/compose/issues/11659)

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
