### PR TITLE
Adds active menu highlight on sidebar && fixes few minor UI bugs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run format:fix
 npm run lint:fix
 

--- a/src/components/Appbar.tsx
+++ b/src/components/Appbar.tsx
@@ -69,7 +69,7 @@ export const Appbar = () => {
         className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background 2xl:flex"
       >
         <div className="flex h-full flex-col gap-4">
-          <div className="flex w-full items-center border-b border-primary/10 p-4">
+          <div className="flex w-full items-center justify-center border-b border-primary/10 p-4">
             {!isCollapsed && (
               <>
                 <h3 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -13,10 +13,7 @@ export const CourseCard = ({
   onClick: () => void;
 }) => {
   const router = useRouter();
-  const imageUrl =
-    course.imageUrl
-      ? course.imageUrl
-      : 'banner_placeholder.png';
+  const imageUrl = course.imageUrl ? course.imageUrl : 'banner_placeholder.png';
   return (
     <div
       className={`flex w-full cursor-pointer flex-col rounded-2xl bg-primary/5 transition-all duration-300 hover:-translate-y-2 hover:border-primary/20`}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -177,7 +177,7 @@ export function Sidebar({
             variants={sidebarVariants}
             className="fixed right-0 top-0 z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
           >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 p-5">
+            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-900 p-5">
               <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
                 Course Content
               </h4>

--- a/src/components/ui/sidebar-items.tsx
+++ b/src/components/ui/sidebar-items.tsx
@@ -25,7 +25,7 @@ export const SidebarItems = ({
   return (
     <>
       {items.map((item) => {
-        const isActive = pathname === item.href;
+        const isActive = pathname.startsWith(item.href);
         return (
           <TooltipProvider key={item.id}>
             <Tooltip>


### PR DESCRIPTION
### PR Fixes:
- Adds highlight stylings for the active menu even on nested routes which wasn't there previously that is right after the new UI revamp (look at the url and sidebar in the below ss)
![image](https://github.com/user-attachments/assets/072e883b-bf49-49c4-80af-48485d333afc)

- Brings the sidebar closed icon in center, which was not justified earlier (it is in the center now)
![image](https://github.com/user-attachments/assets/ab08d25d-2ca2-4456-9d3f-f5fb7b84085e)

- Add bg color to the course content sidebar so that it's text doesn't appear overlapped 
![image](https://github.com/user-attachments/assets/bcbf27c4-6a2d-45bf-b76d-834d96b86857)


Resolves #1028 
Resolves #1167 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
