### PR TITLE
fix: thumbnail-server-action

### DIFF
--- a/src/actions/videopreview/videoPreview.tsx
+++ b/src/actions/videopreview/videoPreview.tsx
@@ -1,18 +1,19 @@
 'use server';
-import db from '@/db';
+// import db from '@/db';
 
 export default async function VideoPreview({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   contentId,
 }: {
   contentId: number;
 }) {
-  const videoMetadata = await db.videoMetadata.findFirst({
-    where: { contentId },
-    select: { video_360p_1: true },
-  });
+  // const videoMetadata = await db.videoMetadata.findFirst({
+  //   where: { contentId },
+  //   select: { video_360p_1: true },
+  // });
 
-  if (videoMetadata) {
-    return videoMetadata.video_360p_1;
-  }
+  // if (videoMetadata) {
+  //   return videoMetadata.video_360p_1;
+  // }
   return null;
 }

--- a/src/components/videothumbnail.tsx
+++ b/src/components/videothumbnail.tsx
@@ -1,27 +1,30 @@
 import React, { useState } from 'react';
-import VideoPreview from '@/actions/videopreview/videoPreview';
-import { useEffect } from 'react';
+// import VideoPreview from '@/actions/videopreview/videoPreview';
+// import { useEffect } from 'react';
 import CardComponent from './CardComponent';
 
 const VideoThumbnail = ({
   imageUrl,
-  contentId,
+  // contentId,
   title,
 }: {
   imageUrl: string;
-  contentId: number;
+  contentId?: number;
   title: string;
 }) => {
-  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [
+    videoUrl,
+    /*setVideoUrl*/
+  ] = useState<string | null>(null);
   const [hover, setHover] = useState(false);
 
-  useEffect(() => {
-    async function fetchVideoUrl() {
-      const url = await VideoPreview({ contentId });
-      setVideoUrl(url);
-    }
-    fetchVideoUrl();
-  }, [contentId]);
+  // useEffect(() => {
+  //   async function fetchVideoUrl() {
+  //     const url = await VideoPreview({ contentId });
+  //     setVideoUrl(url);
+  //   }
+  //   fetchVideoUrl();
+  // }, [contentId]);
   const handleMouseEnter = () => {
     // setHover(true);
   };


### PR DESCRIPTION
### PR Fixes:
- 1 Course page will not leak the content
- 2 Stop unwanted multiple db calls made via server functions.

Resolves #1198

Context: We often think that the server function uses some sort of RPC call under the hood, but that's not the case. Next.js uses an HTTP call to serialize the data to the server. You can see this request(calling server function) in the network tab; the URL will be the same as the current path along with the header 'next-action': "<$7e6r763s34534f345w3434>". This key is associated with the server function, and you can find the function association in the .next folder.

Issue: There was feature which play the video content in the thumbnail which uses server function to get the video Metadata. that server function was unprotected. all I needed was a session with the server and I can get the any course video content. for example I have bought the 1-100 cohort.I was able to see the videos of cohort-3 and cohort-1.

Fix: since we are not using that feature(video player on the thumbnail). I have commented out the server function. may be we might implement that in future with proper authentication.


https://github.com/user-attachments/assets/606855ab-5cde-4b95-a8ae-0776a7d2f486



### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
