### PR TITLE
Issue: #1211

### DIFF
--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -46,6 +46,13 @@ const Signin = () => {
       ...prevState,
       emailReq: false,
     }));
+    
+    // Check if the input is a phone number
+    const phoneNumberRegex = /^[0-9]{10}$/;
+    if (phoneNumberRegex.test(value)) {
+      setSuggestedDomains([]); // Clear suggestions for phone numbers
+      return;
+    }
 
     if (!value.includes('@')) {
       setSuggestedDomains(emailDomains);
@@ -53,6 +60,13 @@ const Signin = () => {
     }
 
     const [, currentDomain] = value.split('@');
+    
+    // Clear suggestions if domain doesn't match
+    if (!currentDomain || !emailDomains.some((domain) => domain.startsWith(currentDomain))) {
+      setSuggestedDomains([]); // Hide suggestions for mismatched domains
+      return;
+    }
+
     // Check for exact matches and filter for partial matches
     const exactMatch = emailDomains.find((domain) => domain === currentDomain);
     if (exactMatch) {
@@ -155,6 +169,7 @@ const Signin = () => {
                 value={email.current}
                 onChange={handleEmailChange}
                 onKeyDown={handleKeyDown}
+                onBlur={() => setSuggestedDomains([])} // Hide suggestions on blur
               />
               {email.current && suggestedDomains.length > 0 && (
                 <ul


### PR DESCRIPTION
### Description
This pull request addresses issues with the email domain suggestions component:

- **Clear suggestions on mismatch**: If the user types a phone number or a custom domain that does not match the preset domains, the suggestions will disappear.
- **Hide suggestions on blur**: If the user doesn’t select a suggestion and clicks outside the input field, the suggestions will be cleared.

### PR Fixes:
- 1 Updated `handleEmailChange` to clear suggestions for phone numbers and mismatched domains.
- 2 Added `onBlur` event handler to clear suggestions when the user clicks outside the input field.

Resolves #1211 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
