### PR TITLE
added background to course-content header

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -177,7 +177,7 @@ export function Sidebar({
             variants={sidebarVariants}
             className="fixed right-0 top-0 z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
           >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 p-5">
+            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 p-5 bg-neutral-50 dark:bg-neutral-900">
               <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
                 Course Content
               </h4>


### PR DESCRIPTION
### PR Fixes:
- on scroll to sidebar, the `course content` heading was overlapping to it's children, for more clarity watch the video

Resolves 

https://github.com/user-attachments/assets/3f194d4e-0e0d-4b4d-b309-bc268843c5cb


https://github.com/user-attachments/assets/a2444c8f-d263-460e-b99d-2ae75d061514



### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
