### PR TITLE
Restrict 3 dots options menu to comment author

### DIFF
--- a/src/components/comment/Comments.tsx
+++ b/src/components/comment/Comments.tsx
@@ -241,36 +241,40 @@ const Comments = async ({
                       )}
                     </div>
 
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <MoreVerticalIcon className="size-6" />
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent>
-                        {(session.user.id.toString() ===
-                          (c as ExtendedComment).userId.toString() ||
-                          session.user.role === ROLES.ADMIN) && (
-                          <DropdownMenuItem>
-                            <CommentDeleteForm commentId={c.id} />
-                          </DropdownMenuItem>
-                        )}
-                        {session.user.role === ROLES.ADMIN && (
-                          <DropdownMenuItem>
-                            <CommentPinForm
-                              commentId={c.id}
-                              contentId={c.contentId}
-                            />
-                          </DropdownMenuItem>
-                        )}
-                        {session.user.role === ROLES.ADMIN && (
-                          <DropdownMenuItem>
-                            <CommentApproveForm
-                              commentId={c.id}
-                              contentId={c.contentId}
-                            />
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                    {(session.user.id.toString() ===
+                      (c as ExtendedComment).userId.toString() ||
+                      session.user.role === ROLES.ADMIN) && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <MoreVerticalIcon className="size-6" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent>
+                          {(session.user.id.toString() ===
+                            (c as ExtendedComment).userId.toString() ||
+                            session.user.role === ROLES.ADMIN) && (
+                            <DropdownMenuItem>
+                              <CommentDeleteForm commentId={c.id} />
+                            </DropdownMenuItem>
+                          )}
+                          {session.user.role === ROLES.ADMIN && (
+                            <DropdownMenuItem>
+                              <CommentPinForm
+                                commentId={c.id}
+                                contentId={c.contentId}
+                              />
+                            </DropdownMenuItem>
+                          )}
+                          {session.user.role === ROLES.ADMIN && (
+                            <DropdownMenuItem>
+                              <CommentApproveForm
+                                commentId={c.id}
+                                contentId={c.contentId}
+                              />
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                   </div>
 
                   <TimeCodeComment


### PR DESCRIPTION
This PR fixes the bug where any user could click on the 3 dots (options menu) for comments not authored by them. The 3 dots are now only visible to the comment's author. This ensures proper access control for comment actions.

Added a check to compare the logged-in user ID with the comment author ID before rendering the options menu.

Resolves #1259

### Checklist before requesting a review
- ✅ I have performed a self-review of my code
- ✅ I assure there is no similar/duplicate pull request regarding same issue

![image](https://github.com/user-attachments/assets/bb468fd2-08df-4dcb-a0e9-327a85607ffe)

