### PR TITLE
feat/auth: Added Authentication Modal Support 

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -4,12 +4,16 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import React from 'react';
 
-const SigninPage = async () => {
+export default async function SignInPage() {
   const session = await getServerSession(authOptions);
   if (session?.user) {
-    redirect('/');
+    redirect('/home');
   }
-  return <Signin />;
-};
-
-export default SigninPage;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-md">
+        <Signin />
+      </div>
+    </div>
+  );
+}

--- a/src/app/@authModal/(.)signin/page.tsx
+++ b/src/app/@authModal/(.)signin/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { CloseButton } from '@/components/CloseButton';
+import Signin from '@/components/Signin';
+import { useRouter } from 'next/navigation';
+import React, { useCallback, useEffect, useState } from 'react';
+
+export default function SigninModal() {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    router.back();
+  }, [router]);
+
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      handleClose();
+    }
+  };
+
+  const handleSignInSuccess = useCallback(() => {
+    setIsOpen(false);
+    router.push('/');
+  }, [router]);
+
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEsc);
+
+    return () => {
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [handleClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      onClick={handleOutsideClick}
+    >
+      <div className="relative w-full max-w-md overflow-hidden rounded-lg bg-background py-4 shadow-lg">
+        <CloseButton onClick={handleClose} />
+        <Signin onSignInSuccess={handleSignInSuccess} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/@authModal/default.tsx
+++ b/src/app/@authModal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,13 @@ const satoshi = localFont({
 
 export const metadata: Metadata = siteConfig;
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function RootLayout({
+  children,
+  authModal,
+}: {
+  children: ReactNode;
+  authModal: ReactNode;
+}) {
   return (
     <html lang="en">
       <body
@@ -33,6 +39,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <GoogleAnalytics />
         <Providers>
           <Navbar />
+          {authModal}
           {children}
           <Toaster richColors />
         </Providers>

--- a/src/components/AppbarAuth.tsx
+++ b/src/components/AppbarAuth.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { signIn } from 'next-auth/react';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { Button } from './ui/button';
 
 export const AppbarAuth = () => {
   const session = useSession();
+  const router = useRouter();
 
   return (
     !session?.data?.user && (
       <Button
         onClick={() => {
-          signIn();
+          router.push('/signin');
         }}
       >
         Login

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -1,0 +1,23 @@
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface CloseButtonProps {
+  onClick: () => void;
+  className?: string;
+}
+
+export function CloseButton({ onClick, className }: CloseButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-sm bg-background text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+        className,
+      )}
+      aria-label="Close"
+    >
+      <X className="h-6 w-6" />
+    </button>
+  );
+}

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -17,7 +17,11 @@ const emailDomains = [
   'rediffmail.com',
 ];
 
-const Signin = () => {
+interface SigninProps {
+  onSignInSuccess?: () => void;
+}
+
+const Signin: React.FC<SigninProps> = ({ onSignInSuccess }) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [checkingPassword, setCheckingPassword] = useState(false);
   const [requiredError, setRequiredError] = useState({
@@ -31,7 +35,7 @@ const Signin = () => {
   const suggestionRefs = useRef<HTMLLIElement[]>([]);
 
   function togglePasswordVisibility() {
-    setIsPasswordVisible((prevState: any) => !prevState);
+    setIsPasswordVisible((prevState: boolean) => !prevState);
   }
   const router = useRouter();
   const email = useRef('');
@@ -112,15 +116,18 @@ const Signin = () => {
 
     toast.dismiss(loadId);
     if (!res?.error) {
-      router.push('/');
       toast.success('Signed In');
+      if (onSignInSuccess) {
+        onSignInSuccess();
+        router.push('/home');
+      }
     } else {
       toast.error('oops something went wrong..!');
       setCheckingPassword(false);
     }
   };
   return (
-    <section className="wrapper relative flex min-h-screen items-center justify-center overflow-hidden antialiased">
+    <section className="wrapper relative flex items-center justify-center overflow-hidden antialiased">
       <motion.div
         initial={{ y: -40, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
@@ -130,7 +137,7 @@ const Signin = () => {
           type: 'spring',
           damping: 10,
         }}
-        className="flex w-full flex-col justify-between gap-12 rounded-2xl bg-primary/5 p-8 md:max-w-[30vw]"
+        className="flex w-full flex-col justify-between gap-12 rounded-2xl bg-primary/5 p-8"
       >
         <div className="flex flex-col text-center">
           <h2 className="text-3xl font-semibold tracking-tighter md:text-4xl">

--- a/src/tests/integration.test.tsx
+++ b/src/tests/integration.test.tsx
@@ -1,5 +1,6 @@
+import SigninPage from '@/app/(auth)/signin/page';
 import { render, screen } from '@testing-library/react';
-import SigninPage from '@/app/signin/page';
+
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { vi } from 'vitest';


### PR DESCRIPTION
### PR Fixes:
- Restructured `(auth)/signin` page and added modal option
- Introduces `CloseButton` component for closing the modal
- Updated `Signin` & `AppbarAuth` for new authentication flow
-  Adjusted import paths and tests to align with the refactored authentication flow

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
- [x] Tested with `.next` build
 
---
### Preview Authentication Modal Support
https://github.com/user-attachments/assets/dc8a93b3-ae13-4ed3-a192-f4abe54f5123

---
### Screenshots (Mobile Preview)

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/c44062ca-2c0b-4f68-9bda-e034d9abb04f" alt="LightMode" /></td>
    <td><img src="https://github.com/user-attachments/assets/c1f4db76-fa90-467c-b248-a54bdb02d41e" alt="DarkMode" /></td>
    <td><img src="https://github.com/user-attachments/assets/a7c30c55-6af3-4563-bb58-d61fabfb1a8f" alt="Signin Route" /></td>
  </tr>
  <tr>
    <td align="center">Light Mode</td>
    <td align="center">Dark Mode</td>
    <td align="center">`/signin` Route</td>
  </tr>
</table>
