### PR TITLE
fix: Quality selector bg issue in light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,10 +129,9 @@
 }
 .vjs-quality-selector .vjs-custom-dropup-menu li {
   padding: 0.5rem 1rem;
-  color: #fff;
 }
 .vjs-quality-selector .vjs-custom-dropup-menu li:hover {
-  background: #444;
+  border-radius: inherit;
 }
 
 /* Custom Tooltip Styling */

--- a/src/components/QualitySelectorControllBar.ts
+++ b/src/components/QualitySelectorControllBar.ts
@@ -24,9 +24,9 @@ class QualitySelectorControllBar extends videojs.getComponent('Button') {
 
     dropUpMenu.innerHTML = `
       <ul class="bg-white dark:bg-gray-800 shadow-lg rounded-md mt-1">
-        <li class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-black dark:text-white" data-quality="1080"">1080p</li>
-        <li class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-black dark:text-white" data-quality="720"">720p</li>
-        <li class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-black dark:text-white" data-quality="360"">360p</li>
+        <li class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-black dark:text-white" data-quality="1080">1080p</li>
+        <li class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-black dark:text-white" data-quality="720">720p</li>
+        <li class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-black dark:text-white" data-quality="360">360p</li>
       </ul>
     `;
 


### PR DESCRIPTION
### PR Fixes:
- 1 Items inside the quality selector in video controls is now visible in light mode
- 2 Remove unnecessary quotations

Resolves #1276 

Before:
![Screenshot (198)](https://github.com/user-attachments/assets/faf29267-68f0-4aee-9bfb-2cded462adbc)

After:
![Screenshot (199)](https://github.com/user-attachments/assets/e5db9d61-ac8d-4bee-a441-7468cf04db4e)


### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I assure there is no similar/duplicate pull request regarding same issue
