### PR TITLE
feat: add dynamic page title for course pages

### DIFF
--- a/src/app/courses/[courseId]/[...moduleId]/page.tsx
+++ b/src/app/courses/[courseId]/[...moduleId]/page.tsx
@@ -1,7 +1,10 @@
+import Head from 'next/head';
 import { QueryParams } from '@/actions/types';
 import { CourseView } from '@/components/CourseView';
 import { getCourse, getFullCourseContent } from '@/db/course';
 import findContentById from '@/lib/find-content-by-id';
+import { TITLE as DEFAULT_TITLE } from '@/config/site-config';
+
 
 export default async function Course({
   params,
@@ -21,16 +24,24 @@ export default async function Course({
     rest.map((x) => parseInt(x, 10)),
   );
   const nextContent = null; //await getNextVideo(Number(rest[rest.length - 1]))
+  const pageTitle = course?.title 
+  ? `${course.title} | 100xDevs` 
+  : DEFAULT_TITLE;
 
   return (
-    <CourseView
-      rest={rest}
-      course={course}
-      nextContent={nextContent}
-      courseContent={courseContent}
-      fullCourseContent={fullCourseContent}
-      searchParams={searchParams}
-      possiblePath={possiblePath}
-    />
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
+      <CourseView
+        rest={rest}
+        course={course}
+        nextContent={nextContent}
+        courseContent={courseContent}
+        fullCourseContent={fullCourseContent}
+        searchParams={searchParams}
+        possiblePath={possiblePath}
+      />
+    </>
   );
 }


### PR DESCRIPTION
- Added dynamic page titles using the course title in `cms/src/app/courses/[courseId]/[...moduleId]/page.tsx`.
- Fallback to default site title if course title is not available.

Resolves #653 

### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I assure there is no similar/duplicate pull request regarding same issue

#### Why?
It was difficult to differentiate between multiple video tabs as they all had the same title. This PR gives each tab a unique title based on the video being watched, making it easier to navigate. Note: This update currently applies only to individual video pages. Plans to extend this to weekly and course pages are in the pipeline.

![image](https://github.com/user-attachments/assets/839a824c-532b-4e83-9497-84fda8a4f28a)
