### PR TITLE
Added authentication to content update apis.

### DIFF
--- a/src/app/api/admin/contentmetadata/route.ts
+++ b/src/app/api/admin/contentmetadata/route.ts
@@ -2,20 +2,29 @@ import db from '@/db';
 import { NextRequest, NextResponse } from 'next/server';
 
 export const POST = async (req: NextRequest) => {
-  const {
-    updates,
-    contentId,
-  }: {
-    updates: any;
-    contentId: number;
-  } = await req.json();
-
-  await db.videoMetadata.update({
-    where: {
+  try {
+    const {
+      updates,
       contentId,
-    },
-    data: updates,
-  });
-
-  return NextResponse.json({}, { status: 200 });
+      adminPassword,
+    }: {
+      updates: any;
+      contentId: number;
+      adminPassword: string;
+    } = await req.json();
+  
+    if (adminPassword !== process.env.ADMIN_SECRET) {
+      return NextResponse.json({}, { status: 403 });
+    }
+    await db.videoMetadata.update({
+      where: {
+        contentId,
+      },
+      data: updates,
+    });
+  
+    return NextResponse.json({}, { status: 200 });
+  } catch (err) {
+    return NextResponse.json({}, { status: 500 });
+  }
 };

--- a/src/app/api/admin/updatecontent/route.ts
+++ b/src/app/api/admin/updatecontent/route.ts
@@ -2,47 +2,57 @@ import db from '@/db';
 import { NextRequest, NextResponse } from 'next/server';
 
 export const POST = async (req: NextRequest) => {
-  const {
-    updates,
-    contentId,
-  }: {
-    updates: any;
-    contentId: number;
-  } = await req.json();
-
-  await db.videoMetadata.update({
-    where: {
+  try {
+    const {
+      updates,
       contentId,
-    },
-    data: {
-      video_360p_1: updates.video_360p,
-      video_360p_2: updates.video_360p,
-      video_360p_3: updates.video_360p,
-      video_360p_4: updates.video_360p,
-      video_720p_1: updates.video_720p,
-      video_720p_2: updates.video_720p,
-      video_720p_3: updates.video_720p,
-      video_720p_4: updates.video_720p,
-      video_1080p_1: updates.video_1080p,
-      video_1080p_2: updates.video_1080p,
-      video_1080p_3: updates.video_1080p,
-      video_1080p_4: updates.video_1080p,
-      /// mp4s
+      adminPassword,
+    }: {
+      updates: any;
+      contentId: number;
+      adminPassword: string;
+    } = await req.json();
 
-      video_1080p_mp4_1: updates.video_1080p_mp4,
-      video_1080p_mp4_2: updates.video_1080p_mp4,
-      video_1080p_mp4_3: updates.video_1080p_mp4,
-      video_1080p_mp4_4: updates.video_1080p_mp4,
-      video_720p_mp4_1: updates.video_720p_mp4,
-      video_720p_mp4_2: updates.video_720p_mp4,
-      video_720p_mp4_3: updates.video_720p_mp4,
-      video_720p_mp4_4: updates.video_720p_mp4,
-      video_360p_mp4_1: updates.video_360p_mp4,
-      video_360p_mp4_2: updates.video_360p_mp4,
-      video_360p_mp4_3: updates.video_360p_mp4,
-      video_360p_mp4_4: updates.video_360p_mp4,
-    },
-  });
+    if (adminPassword !== process.env.ADMIN_SECRET) {
+      return NextResponse.json({}, { status: 403 });
+    }
 
-  return NextResponse.json({}, { status: 200 });
+    await db.videoMetadata.update({
+      where: {
+        contentId,
+      },
+      data: {
+        video_360p_1: updates.video_360p,
+        video_360p_2: updates.video_360p,
+        video_360p_3: updates.video_360p,
+        video_360p_4: updates.video_360p,
+        video_720p_1: updates.video_720p,
+        video_720p_2: updates.video_720p,
+        video_720p_3: updates.video_720p,
+        video_720p_4: updates.video_720p,
+        video_1080p_1: updates.video_1080p,
+        video_1080p_2: updates.video_1080p,
+        video_1080p_3: updates.video_1080p,
+        video_1080p_4: updates.video_1080p,
+        /// mp4s
+  
+        video_1080p_mp4_1: updates.video_1080p_mp4,
+        video_1080p_mp4_2: updates.video_1080p_mp4,
+        video_1080p_mp4_3: updates.video_1080p_mp4,
+        video_1080p_mp4_4: updates.video_1080p_mp4,
+        video_720p_mp4_1: updates.video_720p_mp4,
+        video_720p_mp4_2: updates.video_720p_mp4,
+        video_720p_mp4_3: updates.video_720p_mp4,
+        video_720p_mp4_4: updates.video_720p_mp4,
+        video_360p_mp4_1: updates.video_360p_mp4,
+        video_360p_mp4_2: updates.video_360p_mp4,
+        video_360p_mp4_3: updates.video_360p_mp4,
+        video_360p_mp4_4: updates.video_360p_mp4,
+      },
+    });
+  
+    return NextResponse.json({}, { status: 200 });
+  } catch (err) {
+    return NextResponse.json({}, { status: 500 });
+  }
 };

--- a/src/components/admin/UpdateVideoClient.tsx
+++ b/src/components/admin/UpdateVideoClient.tsx
@@ -35,6 +35,7 @@ export const UpdateVideoClient = ({
   const [pdfLink, setPdfLink] = useState('');
   const [vttLink, setVttLink] = useState('');
 
+  const [adminPassword, setAdminPassword] = useState('');
   return (
     <div className='max-w-7xl mx-auto px-4'>
 
@@ -108,10 +109,18 @@ export const UpdateVideoClient = ({
                   }}
                   placeholder={'m3u8 360p'}
                 />
+                <Label className="mt-4">Admin Password</Label>
+                <Input
+                  type="text"
+                  placeholder="Admin password"
+                  onChange={(e) => setAdminPassword(e.target.value)}
+                  className="h-14"
+                />
                 <Button
-                  className="my-4 rounded  p-2 font-bold text-white w-full lg:w-[20%]"
+                  className="my-4 w-full rounded p-2 font-bold text-white lg:w-[20%]"
                   onClick={async () => {
                     await axios.post('/api/admin/updatecontent', {
+                      adminPassword,
                       contentId: content.id,
                       updates: {
                         video_360p: link360,

--- a/src/components/admin/UpdateVideoClient.tsx
+++ b/src/components/admin/UpdateVideoClient.tsx
@@ -161,10 +161,17 @@ export const UpdateVideoClient = ({
                   }}
                   placeholder={'pdf link'}
                 />
+                <Input
+                  type="text"
+                  placeholder="Admin password"
+                  onChange={(e) => setAdminPassword(e.target.value)}
+                  className="h-14"
+                />
                 <Button
                   className="my-4 rounded p-2 font-bold text-white w-full lg:w-[20%]"
                   onClick={async () => {
                     await axios.post('/api/admin/contentmetadata', {
+                      adminPassword,
                       contentId: content.id,
                       updates: {
                         slides: pdfLink,
@@ -199,10 +206,17 @@ export const UpdateVideoClient = ({
                   }}
                   placeholder={'vtt link'}
                 />
+                <Input
+                  type="text"
+                  placeholder="Admin password"
+                  onChange={(e) => setAdminPassword(e.target.value)}
+                  className="h-14"
+                />
                 <Button
                   className="my-4 rounded  p-2 font-bold text-white w-full lg:w-[20%]"
                   onClick={async () => {
                     await axios.post('/api/admin/contentmetadata', {
+                      adminPassword,
                       contentId: content.id,
                       updates: {
                         subtitles: vttLink,

--- a/src/components/admin/UpdateVideoClient.tsx
+++ b/src/components/admin/UpdateVideoClient.tsx
@@ -114,7 +114,6 @@ export const UpdateVideoClient = ({
                   type="text"
                   placeholder="Admin password"
                   onChange={(e) => setAdminPassword(e.target.value)}
-                  className="h-14"
                 />
                 <Button
                   className="my-4 w-full rounded p-2 font-bold text-white lg:w-[20%]"
@@ -165,7 +164,6 @@ export const UpdateVideoClient = ({
                   type="text"
                   placeholder="Admin password"
                   onChange={(e) => setAdminPassword(e.target.value)}
-                  className="h-14"
                 />
                 <Button
                   className="my-4 rounded p-2 font-bold text-white w-full lg:w-[20%]"
@@ -210,7 +208,7 @@ export const UpdateVideoClient = ({
                   type="text"
                   placeholder="Admin password"
                   onChange={(e) => setAdminPassword(e.target.value)}
-                  className="h-14"
+                  className="my-3"
                 />
                 <Button
                   className="my-4 rounded  p-2 font-bold text-white w-full lg:w-[20%]"


### PR DESCRIPTION
### PR Fixes:
- There are two api used update the videoMetadata :  ``` api/admin/updatecontent ``` and ``` api/admin/contentmetadata ```. rn anyone with or without logging can change or delete the videoMetadata based on content id. Added the admin-password check for the same.

Test: this was my api payload that cleared all the link from columns for endpoint :- contentmetadata 
```
{
    "contentId" : 3,
    "updates": {}
}
```

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
