### PR TITLE
fix: Main heading hidden behind navbar (#1294)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -177,7 +177,7 @@ export function Sidebar({
             variants={sidebarVariants}
             className="fixed right-0 top-0 z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
           >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 p-5">
+            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 p-5 backdrop-blur-md">
               <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
                 Course Content
               </h4>

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -31,7 +31,7 @@ const heroItems = [
 export default function LandingPage() {
   return (
     <div className="flex min-h-screen flex-col">
-      <main className="flex h-[100vh] flex-col items-center justify-center gap-4">
+      <main className="flex h-full flex-col items-center justify-center gap-4">
         {/* Hero */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -45,7 +45,7 @@ export default function LandingPage() {
           }}
           className="flex max-w-7xl flex-col items-center justify-center gap-2 px-4"
         >
-          <h1 className="max-w-2xl py-2 text-center text-5xl font-extrabold tracking-tighter md:text-6xl xl:text-7xl">
+          <h1 className="max-w-2xl py-2 pt-36 text-center text-5xl font-extrabold tracking-tighter md:text-6xl xl:text-7xl">
             <span className="w-fit bg-gradient-to-b from-blue-400 to-blue-700 bg-clip-text pr-1.5 text-center text-transparent md:mb-4">
               100xDevs,
             </span>{' '}
@@ -69,7 +69,7 @@ export default function LandingPage() {
             damping: 10,
             stiffness: 100,
           }}
-          className="flex items-center justify-center gap-2"
+          className="flex items-center justify-center gap-2 py-5"
         >
           <Button size={'lg'} asChild variant={'branding'}>
             <Link


### PR DESCRIPTION
### PR Fixes:
- 1 Fixes NavBar overlapping title on the Home page
- 2 Fixes course carousel getting cropped on zoomed screen

Resolves #1294
![image](https://github.com/user-attachments/assets/8fe569fc-e3d2-433d-ac8d-f8ca9daec3d8)

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding the same issue
