### PR TITLE
Fix new UI bug

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -38,8 +38,8 @@ export const CourseView = ({
     ? 'folder'
     : courseContent?.value.type;
   return (
-    <div className="flex w-full flex-col gap-8 pb-16 pt-8">
-      <div className="flex flex-col gap-4">
+    <div className="flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
+      <div className="flex flex-col gap-4 xl:pt-44">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -182,7 +182,7 @@ export function Sidebar({
 
   return (
     <>
-      <Button onClick={() => setSidebarOpen((s) => !s)} className="w-fit gap-2">
+      <Button onClick={() => setSidebarOpen((s) => !s)} className="w-fit gap-2 xl:absolute">
         {sidebarOpen ? <X className="size-5" /> : <Menu className="size-5" />}
         <span>{sidebarOpen ? 'Hide Contents' : 'Show Contents'}</span>
       </Button>


### PR DESCRIPTION
### PR Fixes:
- Fixed the issue where the video player was taking so much space that its part was being cut when on higher resolution

### Old UI
![Screenshot 2024-09-19 035109](https://github.com/user-attachments/assets/4ea09882-d621-490b-bb51-9a95e47a476f)

### New UI
![Screenshot 2024-09-19 034848](https://github.com/user-attachments/assets/620a7384-ede2-4cda-94cf-2743ca4bb56f)

### Responsiveness?
![Screenshot 2024-09-19 034930](https://github.com/user-attachments/assets/902d82f5-8b87-4756-bf98-1cafd337f579)

### What does it Resolve?
- For devices with a width greater than 1280px, the path and the button are on the same line.
- For all others, it's the same as it is.

### What is changed?
- For 'xl' size and above, the CSS property changed to absolute and overlapped the button component.
- Made the z-index of button 50 to it to work.
- Tested in many scenarios.

_### Open for any other Suggestions or Changes_

Resolves #1180 

### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I assure there is no similar/duplicate pull request regarding same issue
