### PR TITLE
Fixes: #1361  Breaking words instead of truncate for longer titles.

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -157,10 +157,12 @@ export function Sidebar({
           >
             <div className="flex w-full items-center justify-between gap-2">
               <div className="flex items-center gap-2">
-                <Check content={content} />
-                {content.type === 'video' && <Play className="size-4" />}
-                {content.type === 'notion' && <File className="size-4" />}
-                <div className="truncate text-base">{content.title}</div>
+                <div className="flex gap-2">
+                  <Check content={content} />
+                  {content.type === 'video' && <Play className="size-4" />}
+                  {content.type === 'notion' && <File className="size-4" />}
+                </div>
+                <div className="break-words text-base">{content.title}</div>
               </div>
               {content.type === 'video' && (
                 <BookmarkButton


### PR DESCRIPTION
### PR Fixes:
- Resolves the issue with longer titles in SideBar, by breaking the title instead of truncating it.

Resolves #1361 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
