### PR TITLE
FIX: Typescript error for react 17 or above

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
### PR Fixes:
<img width="818" alt="Screenshot 2024-10-02 at 8 20 02 PM" src="https://github.com/user-attachments/assets/afd01246-682f-44f5-b871-0bf4475d0d2d">

In react 17 or above the follwoing change can help to not use React import in each file other wise it shows a warning as you can see in the screenshot attached


### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue
