### PR TITLE
Feat: Auto assign issues workflow

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,55 @@
+name: Auto Assign Issue
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const triggerWords = ['take', 'assign me', 'I\'ll work on this'];
+            const comment = context.payload.comment.body.toLowerCase();
+            
+            if (triggerWords.some(word => comment.includes(word))) {
+              const issue = context.payload.issue;
+              const commenter = context.payload.comment.user.login;
+              
+              try {
+                if (!issue.assignees || issue.assignees.length === 0) {
+                  await github.rest.issues.addAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    assignees: [commenter]
+                  });
+                  
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `@${commenter} has been assigned to this issue.`
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `This issue is already assigned to someone else.`
+                  });
+                }
+              } catch (error) {
+                console.error('Error:', error);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `An error occurred while trying to assign this issue. Please contact a repository maintainer.`
+                });
+              }
+            }


### PR DESCRIPTION
Feature Summary    issues-1377

New GitHub Actions workflow
Automatically assigns issues to users who comment with trigger words (e.g., "take", "assign me")

Implementation
Workflow file: .github/workflows/auto-assign-issue.yml
Requires PERSONAL_ACCESS_TOKEN secret

Security
Only assigns unassigned issues
PAT stored as a repository secret

<img width="1052" alt="Screenshot 2024-10-03 at 12 45 36 AM" src="https://github.com/user-attachments/assets/318a2adb-b8f1-4cca-b07e-4553be4eac79">
<img width="1324" alt="Screenshot 2024-10-03 at 12 46 16 AM" src="https://github.com/user-attachments/assets/70927a48-cfd9-4efd-ab34-995f3f414564">
