### PR TITLE
bug: show content button hide the Breadcrumb #1389

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -183,7 +183,7 @@ export function Sidebar({
 
   return (
     <>
-      <Button onClick={() => setSidebarOpen((s) => !s)} className="w-fit gap-2 xl:absolute">
+      <Button onClick={() => setSidebarOpen((s) => !s)} className="w-fit gap-2">
         {sidebarOpen ? <X className="size-5" /> : <Menu className="size-5" />}
         <span>{sidebarOpen ? 'Hide Contents' : 'Show Contents'}</span>
       </Button>


### PR DESCRIPTION
### PR Fixes:
- 1 bug: show content button hide the Breadcrumb #1389
![image](https://github.com/user-attachments/assets/9c4e5557-8ae2-43ec-abb9-009889838ac9)
![image](https://github.com/user-attachments/assets/8cb3cc73-2814-4ae4-9753-0e7cb7b98356)


Resolves #[ #1389]  #[#1380]

### Checklist before requesting a review
- [yes ] I have performed a self-review of my code
- [yes ] I assure there is no similar/duplicate pull request regarding same issue
