### PR TITLE
[fix] show content button position conflict (#1446)

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -38,7 +38,7 @@ export const CourseView = ({
     ? 'folder'
     : courseContent?.value.type;
   return (
-    <div className="flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
+    <div className="flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[45px]">
       <div className="flex flex-col gap-4 xl:pt-2">
         <BreadCrumbComponent
           course={course}


### PR DESCRIPTION
### PR Fixes:
- 1 Fixed overlapping of the card view that contains the path, which was getting hidden behind the "Show" button by increasing the padding of the card view

Resolves #1446  

### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue
