### PR TITLE
added the duration of videos in sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -164,7 +164,17 @@ export function Sidebar({
                   {content.type === 'video' && <Play className="size-4" />}
                   {content.type === 'notion' && <File className="size-4" />}
                 </div>
-                <div className="break-words text-base">{content.title}</div>
+                <div className="flex flex-col">
+                  <div className="break-words text-base">{content.title}</div>
+                  {content.type === 'video' && (
+                    <div className="w-full text-xs">
+                      {content.VideoMetadata?.duration
+                        ? `${Math.floor(content.VideoMetadata.duration / 60) > 0 ? `${Math.floor(content.VideoMetadata.duration / 60)} hr` : ''} 
+    ${Math.floor(content.VideoMetadata.duration % 60) > 0 ? ` ${Math.floor(content.VideoMetadata.duration % 60)} min` : ''}`.trim()
+                        : ''}
+                    </div>
+                  )}
+                </div>
               </div>
               {content.type === 'video' && (
                 <BookmarkButton


### PR DESCRIPTION
### PR Fixes:
- 1 The duration of video in the sidebar

Resolves #1487 

Testing for personalized durations - 40, 60, 140, 0 / null
![showDuration40](https://github.com/user-attachments/assets/0c116f8d-129f-4d6b-bc76-1692f922fdcd)
![showDuration60](https://github.com/user-attachments/assets/a8e109eb-287e-4d3d-aca6-995c1040a936)
![showDuration140](https://github.com/user-attachments/assets/b39145c9-9cd4-456c-aff4-404d6f73eede)
![showDuration0](https://github.com/user-attachments/assets/ae3bb1d6-7461-4f79-9458-ba6d1b7d0e41)

### Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I assure there is no similar/duplicate pull request regarding same issue
