### PR TITLE
fix: typo fixed from stroke-linecap to strokeLinecap

### DIFF
--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -51,7 +51,7 @@ const Footer = () => {
                     <path
                       d="M13.530750000000001 0.7153750000000001 1.46925 14.284625"
                       stroke="currentColor"
-                      stroke-linecap="round"
+                      strokeLinecap="round"
                       strokeWidth="1"
                     ></path>
                   </svg>


### PR DESCRIPTION
### PR Fixes:
1. Fixes the typo in the SVG property from stroke-linecap to strokeLinecap, resolving the invalid DOM property warning.


Resolves #1491

### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I assure there is no similar/duplicate pull request regarding same issue
