### PR TITLE
fix: Resolve sidebar clipping behind topbar and bottombar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -186,7 +186,7 @@ export function Sidebar({
   );
 
   return (
-    <div className='sticky top-[72px] z-20 bg-background py-2'>
+    <div className="sticky top-[72px] z-20 bg-background py-2">
       <Button
         ref={buttonRef}
         onClick={() => setSidebarOpen((s) => !s)}
@@ -204,9 +204,10 @@ export function Sidebar({
             ref={sidebarRef}
             exit="closed"
             variants={sidebarVariants}
-            className="fixed right-0 top-0 z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
+            className="fixed right-0 top-[72px] z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
           >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-50 p-5 dark:bg-neutral-900">              <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
+            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-50 p-5 dark:bg-neutral-900">
+              <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
                 Course Content
               </h4>
               <Button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -204,7 +204,7 @@ export function Sidebar({
             ref={sidebarRef}
             exit="closed"
             variants={sidebarVariants}
-            className="fixed right-0 top-[72px] z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
+            className="fixed right-0 top-[72px] z-[99999] flex h-[calc(100vh-72px-72px)] w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw] 2xl:h-screen"
           >
             <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-50 p-5 dark:bg-neutral-900">
               <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">


### PR DESCRIPTION
### PR Fixes:
- 1 Fixed sidebar which was rendered behind topbar and bottombar

Resolves #[Issue Number if there] 

Before:
(behind topbar)
![Screenshot 2024-10-26 120328](https://github.com/user-attachments/assets/117f3b9e-d971-4e58-b361-946fccac6f83)
(behind bottombar)
![Screenshot 2024-10-26 124128](https://github.com/user-attachments/assets/01a05593-7010-4e05-80a4-69ea8800c372)


After:
![Screenshot 2024-10-26 120344](https://github.com/user-attachments/assets/8291d22b-62aa-49d4-ac38-2d229b3bc5fc)


### Checklist before requesting a review
- [X] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
