### PR TITLE
Fix: Ensure last accordion item is fully visible above bottom navigation

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -186,7 +186,7 @@ export function Sidebar({
   );
 
   return (
-    <div className='sticky top-[72px] z-20 bg-background py-2'>
+    <div className="sticky top-[72px] z-20 bg-background py-2">
       <Button
         ref={buttonRef}
         onClick={() => setSidebarOpen((s) => !s)}
@@ -206,7 +206,9 @@ export function Sidebar({
             variants={sidebarVariants}
             className="fixed right-0 top-0 z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
           >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-50 p-5 dark:bg-neutral-900">              <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
+            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-50 p-5 dark:bg-neutral-900">
+              {' '}
+              <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
                 Course Content
               </h4>
               <Button
@@ -217,7 +219,7 @@ export function Sidebar({
                 <X className="size-5" />
               </Button>
             </div>
-            <Accordion type="multiple" className="w-full px-4 capitalize">
+            <Accordion type="multiple" className="w-full px-4 pb-20 capitalize">
               {memoizedContent}
             </Accordion>
           </motion.div>


### PR DESCRIPTION
### PR Fixes:
- 1 Fixes last item visibility in the accordion list, ensuring the bottom item is fully accessible above the bottom navigation bar.
- 2 Adjusts padding to prevent UI elements from being hidden behind the navigation bar.

Resolves #1544 

### Checklist before requesting a review
- [x] I have performed a self-review of my code to confirm the fix.
- [x] I have checked for any existing PRs to ensure there is no duplicate addressing the same issue.
- [x] I have tested the changes on multiple screen sizes to verify the fix.
