### PR TITLE
minor: Fixed hidden closing button of Sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -204,7 +204,7 @@ export function Sidebar({
             ref={sidebarRef}
             exit="closed"
             variants={sidebarVariants}
-            className="fixed right-0 top-0 z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
+            className="fixed right-0 top-[64px] z-[99999] flex h-screen w-full flex-col gap-4 overflow-y-auto rounded-r-lg border-l border-primary/10 bg-neutral-50 dark:bg-neutral-900 md:max-w-[30vw]"
           >
             <div className="sticky top-0 z-10 flex items-center justify-between border-b border-primary/10 bg-neutral-50 p-5 dark:bg-neutral-900">              <h4 className="text-xl font-bold tracking-tighter text-primary lg:text-2xl">
                 Course Content


### PR DESCRIPTION
Fixed closing button of the sidebar.

Before:
![Screenshot (377)](https://github.com/user-attachments/assets/f97c07d8-33aa-4461-aea6-d252b50f01ba)

After:
![Screenshot (376)](https://github.com/user-attachments/assets/0765e2e7-0670-4ee1-b8f2-d5fc80fb0a0e)

Changed CSS from `top-0` to `top-[64px]`... WHY 64PX??

**Explanation:**

In tailwind.config.js, we have defined height of the sidebar as `100vh-64px`:

https://github.com/code100x/cms/blob/204c49667b386c29cc9699180adce5775c5df7dc/tailwind.config.js#L87-L89

Similarly in tailwind.css:

https://github.com/code100x/cms/blob/204c49667b386c29cc9699180adce5775c5df7dc/src/styles/tailwind.css#L1053-L1055

But the sidebar had inline TailwindCSS in which we defined `top-0` so it was sticking to the top and was getting covered by navbar.