### PR TITLE
Fix: Ensure captions settings are visible on dark as well as light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,13 +231,13 @@
 @layer utilities {
   /* Hide scrollbar for Chrome, Safari and Opera */
   .no-scrollbar::-webkit-scrollbar {
-      display: none;
+    display: none;
   }
- /* Hide scrollbar for IE, Edge and Firefox */
+  /* Hide scrollbar for IE, Edge and Firefox */
   .no-scrollbar {
-      -ms-overflow-style: none;  /* IE and Edge */
-      scrollbar-width: none;  /* Firefox */
-}
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
 }
 
 .markdown-editor-default-font {
@@ -355,4 +355,7 @@
   to {
     mask-size: 350vmax;
   }
+}
+select {
+  background-color: #000;
 }


### PR DESCRIPTION
### PR Fixes:
- 1 Fixed captions settings visibility in light mode
- 2 Adjusted background color

Resolves #1549 

**Screenshots**

![Screenshot from 2024-11-13 00-42-09](https://github.com/user-attachments/assets/91edf4ce-98d9-4f91-be3f-7095de8a7452)
![Screenshot from 2024-11-13 00-42-15](https://github.com/user-attachments/assets/101b98a3-fd2d-4c0d-8112-746ccb98aa40)


### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I assure there is no similar/duplicate pull request regarding same issue.
- [x] I have tested the changes on multiple screen sizes to verify the fix.
