### PR TITLE
Fixing/scroll bar restoration

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,7 +16,6 @@ const scrollPositions = new Map<string, number>();
 
 export const Navbar = () => {
   const { data: session } = useSession();
-  const router = useRouter();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const pathname = usePathname();

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Menu, Search, X } from 'lucide-react';
 import { Button } from './ui/button';
@@ -11,6 +11,8 @@ import { AppbarAuth } from './AppbarAuth';
 import ThemeToggler from './ThemeToggler';
 import ProfileDropdown from './profile-menu/ProfileDropdown';
 import { SearchBar } from './search/SearchBar';
+
+const scrollPositions = new Map<string, number>();
 
 export const Navbar = () => {
   const { data: session } = useSession();
@@ -40,6 +42,34 @@ export const Navbar = () => {
     [],
   );
 
+  // Save scroll position when leaving a page
+
+  useEffect(() => {
+    const handleScroll = () => {
+      scrollPositions.set(pathname, window.scrollY);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [pathname]);
+
+  // Custom back navigation with scroll position restoration
+
+  const handleBack = useCallback(() => {
+    scrollPositions.set(pathname, window.scrollY);
+
+    // Use window.history to go back
+    window.history.back();
+
+    // Restore scroll position after a short delay to ensure the page has loaded
+    setTimeout(() => {
+      const previousPath = window.location.pathname;
+      const savedPosition = scrollPositions.get(previousPath) || 0;
+      window.scrollTo(0, savedPosition);
+    }, 100);
+  }, [pathname]);
+
   return (
     <>
       <motion.nav
@@ -63,7 +93,7 @@ export const Navbar = () => {
           >
             {session?.user && pathname !== '/home' && (
               <Button
-                onClick={() => router.back()}
+                onClick={handleBack}
                 variant={'ghost'}
                 size={'icon'}
                 className="flex items-center gap-2"
@@ -158,9 +188,9 @@ export const Navbar = () => {
                 exit={{ opacity: 0, y: -20 }}
               >
                 <AppbarAuth />
-                  <Button variant={'branding'} className="w-full">
+                <Button variant={'branding'} className="w-full">
                   <Link
-                      href={'https://harkirat.classx.co.in/new-courses'}
+                    href={'https://harkirat.classx.co.in/new-courses'}
                     target="_blank"
                   >
                     Join now

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSession } from 'next-auth/react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Menu, Search, X } from 'lucide-react';


### PR DESCRIPTION
PR Fixes:

Fixed scroll position reset when using navbar back button
Added scroll position preservation across navigation
Improved user experience by maintaining scroll state

Checklist before requesting a review

 I have performed a self-review of my code
 I assure there is no similar/duplicate pull request regarding same issue

Testing Steps

Open any long content page
Scroll down partially
Navigate away
Click back button in navbar
Verify scroll position is maintained

Notes

No new dependencies added
Works on both mobile and desktop