### PR TITLE
 Resolve overlap issue of the last sidebar element with the footer menu across all devices

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
-}

--- a/src/components/Appbar.tsx
+++ b/src/components/Appbar.tsx
@@ -49,7 +49,7 @@ export const Appbar = () => {
   const toggleCollapse = () => setIsCollapsed(!isCollapsed);
 
   const sidebarVariants = {
-    expanded: { width: '12vw' },
+    expanded: { width: '20vw' },
     collapsed: { width: '4vw' },
   };
 
@@ -66,7 +66,7 @@ export const Appbar = () => {
           stiffness: 200,
           damping: 20,
         }}
-        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background 2xl:flex"
+        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex"
       >
         <div className="flex h-full flex-col gap-4">
           <div className="flex w-full items-center border-b border-primary/10 px-2 py-4">
@@ -97,7 +97,7 @@ export const Appbar = () => {
         initial={{ y: 100 }}
         animate={{ y: 0 }}
         transition={{ duration: 0.3, ease: 'easeInOut' }}
-        className="fixed bottom-0 left-0 right-0 z-[999] 2xl:hidden"
+        className="fixed bottom-0 left-0 right-0 z-[999] lg:hidden"
       >
         <div className="flex items-center justify-around border-t border-primary/10 bg-background p-4 shadow-xl">
           <SidebarItems items={menuOptions} isCollapsed={!isMediumToXL} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -265,7 +265,7 @@ export function Sidebar({
             <Accordion
               type="multiple"
               defaultValue={currentActiveContentIds.map((num) => `item-${num}`)}
-              className="w-full px-4 capitalize"
+              className="w-full px-4 capitalize pb-24"
             >
               {memoizedContent}
             </Accordion>


### PR DESCRIPTION
### PR Fixes:  
- Last sidebar element being overlapped by the footer menu on all devices (mobile, tablet, laptop)
- Improved sidebar responsiveness for large screen sizes

**Issue Description:**
1. The last element of the sidebar was always overlapped by the footer menu, causing usability issues. This problem occurred consistently across all screen sizes.
2. Navigation was not optimally responsive for 13-inch laptop screens.

**Fix Description:**
1. Applied a padding-bottom of `6rem` to the sidebar to ensure sufficient space for the last element to be visible above the footer menu.
2. Updated Tailwind responsive classes from `2xl` to `lg` in AppBar component
3. Increased the AppBar width from 12vw to 20vw to accommodate all navigation items on smaller screens
4. Implemented a more consistent navigation experience across different device sizes

### Checklist before requesting a review:
- [x] I have performed a self-review of my code
- [x] Addressed mentor's feedback on navigation responsiveness
- [x] Ensured no similar/duplicate pull request exists
- [x] Tested across multiple device sizes

### Screenshots of the overlaping Issue (Mobile)  

| **Before (Issue)**                        | **After (Fixed)**                         |  
|-------------------------------------------|-------------------------------------------|  
| <img width="199" alt="Mobile Before" src="https://github.com/user-attachments/assets/b2c458df-1531-44d3-bce5-928ed55da2b1"> | <img width="199" alt="Mobile After" src="https://github.com/user-attachments/assets/cc70ce5a-e4d1-468c-a6e6-a245db3bc99c"> |  

### Screenshots of changes sidebar layout(1024px - Laptop Screen Width)

| **Before (Old Implementation)** | **New Implementation (Sidebar Closed)** | **New Implementation (Sidebar Open)** |
|---------------------------------|------------------------------------------|---------------------------------------|
| <img width="513" alt="Before Screenshot" src="https://github.com/user-attachments/assets/486b44e1-9ae2-469c-b049-78251881bedf"> | <img width="515" alt="Sidebar Open Screenshot" src="https://github.com/user-attachments/assets/dff53b20-bfbf-4cf3-8c0f-d24fbfe14ada"> | <img width="519" alt="Sidebar Closed Screenshot" src="https://github.com/user-attachments/assets/97daefa6-9683-4c5a-836c-281a446bc216"> |


**Observations at 1024px:**
- Sidebar now fully visible and functional
- All menu items accessible
- Consistent layout with larger screen designs

### Additional Notes
- Week 17 (previously cut-off last item) is now fully visible on mobile devices
- Navigation is now responsive and consistent across different screen sizes
- Bottom padding ensures no content is hidden by footer menu

@hkirat @siinghd @devsargam 