### PR TITLE
Fix App Bar Icon Shrinking and Wrapper Overlapping with main contents Issues

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,7 +216,7 @@
 
 @layer utilities {
   .wrapper {
-    @apply h-full w-full max-w-7xl px-4 py-4 md:px-12 lg:pl-20 lg:pr-12 lg:mx-auto xl:max-w-[90rem];
+    @apply h-full w-full max-w-7xl px-4 py-4 md:px-12 lg:px-20 lg:mx-auto xl:max-w-[90rem];
   }
 
   .flex-center {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,7 +216,7 @@
 
 @layer utilities {
   .wrapper {
-    @apply h-full w-full max-w-7xl px-4 py-4 md:px-12 lg:mx-auto xl:max-w-[90rem];
+    @apply h-full w-full max-w-7xl px-4 py-4 md:px-12 lg:pl-20 lg:pr-12 lg:mx-auto xl:max-w-[90rem];
   }
 
   .flex-center {

--- a/src/components/Appbar.tsx
+++ b/src/components/Appbar.tsx
@@ -66,7 +66,7 @@ export const Appbar = () => {
           stiffness: 200,
           damping: 20,
         }}
-        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex min-w-8"
+        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex min-w-16"
       >
         <div className="flex h-full flex-col gap-4">
           <div className="flex w-full items-center border-b border-primary/10 px-2 py-4">

--- a/src/components/Appbar.tsx
+++ b/src/components/Appbar.tsx
@@ -66,7 +66,7 @@ export const Appbar = () => {
           stiffness: 200,
           damping: 20,
         }}
-        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex"
+        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex min-w-[3.7rem]"
       >
         <div className="flex h-full flex-col gap-4">
           <div className="flex w-full items-center border-b border-primary/10 px-2 py-4">

--- a/src/components/Appbar.tsx
+++ b/src/components/Appbar.tsx
@@ -66,7 +66,7 @@ export const Appbar = () => {
           stiffness: 200,
           damping: 20,
         }}
-        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex min-w-[3.7rem]"
+        className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex min-w-8"
       >
         <div className="flex h-full flex-col gap-4">
           <div className="flex w-full items-center border-b border-primary/10 px-2 py-4">


### PR DESCRIPTION
### PR Fixes:
- Fixed app bar icon sizing by setting the min-width to 3.7rem (previously, the width was set to 4vw with no min-width), leading to  icons shrinking to an unusually small size.
- Increased padding in the wrapper to resolve the overlapping issue between the app bar and buttons.  

### Before and After Screenshots  

| **State**   | **Screenshot**          |  
|-------------|-------------------------|  
| **Before**  | <img width="1280" alt="Screenshot 2024-12-06 at 6 48 34 PM" src="https://github.com/user-attachments/assets/6a5327ba-3528-446a-84d1-eeefa6cddedb"> |  
| **After**   | <img width="1280" alt="Screenshot 2024-12-06 at 6 47 07 PM" src="https://github.com/user-attachments/assets/bb20e789-f5e7-4f4e-8422-fb717a02b326"> |  




### Checklist Before Requesting a Review
- [x] I have performed a self-review of my code.  
- [x] I assure there is no similar/duplicate pull request regarding the same issue.  

@devsargam @siinghd 
