### PR TITLE
fix: iframe-video positioning and width fixes along with some accordion styling fixes 

### DIFF
--- a/src/app/courses/[courseId]/layout.tsx
+++ b/src/app/courses/[courseId]/layout.tsx
@@ -49,11 +49,11 @@ const Layout = async ({
   const fullCourseContent = await getFullCourseContent(parseInt(courseId, 10));
   return (
     <div className="relative flex min-h-screen flex-col py-24">
-      <div className="flex justify-between">
+      <div className="flex justify-between items-center">
         <div className="2/3">
           <Sidebar fullCourseContent={fullCourseContent} courseId={courseId} />
         </div>
-        <div className="w-1/3">
+        <div>
           <FilterContent />
         </div>
       </div>

--- a/src/components/AppxVideoPlayer.tsx
+++ b/src/components/AppxVideoPlayer.tsx
@@ -38,7 +38,7 @@ export const AppxVideoPlayer = ({
   }
   return <iframe
     src={url}
-    className="h-[80vh] w-[80vw] rounded-lg"
+    className="w-full rounded-lg aspect-video"
     allowFullScreen
   ></iframe >;
 };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,7 +80,7 @@ export const Navbar = () => {
                 className="size-10 rounded-full"
               />
               <p
-                className={`hidden bg-gradient-to-b from-blue-400 to-blue-700 bg-clip-text text-2xl font-black tracking-tighter text-transparent min-[375px]:block`}
+                className={`hidden bg-gradient-to-b from-blue-400 to-blue-700 bg-clip-text text-2xl font-black tracking-tighter text-transparent min-[410px]:block`}
               >
                 100xDevs
               </p>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -231,7 +231,7 @@ export function Sidebar({
   );
 
   return (
-    <div className="sticky top-[72px] z-20 bg-background py-2">
+    <div className="sticky top-[72px] z-20 py-2">
       <Button
         ref={buttonRef}
         onClick={() => setSidebarOpen((s) => !s)}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -271,7 +271,7 @@ export function Sidebar({
             <Accordion
               type="multiple"
               defaultValue={currentActiveContentIds.map((num) => `item-${num}`)}
-              className="w-full px-4 pb-24 capitalize"
+              className="w-full px-4 pb-40 capitalize"
             >
               {memoizedContent}
             </Accordion>

--- a/src/components/VideoPlayerSegment.tsx
+++ b/src/components/VideoPlayerSegment.tsx
@@ -98,7 +98,7 @@ export const VideoPlayerSegment: FunctionComponent<VideoProps> = ({
         <div
           id="thumbnail-preview"
           ref={thumbnailPreviewRef}
-          className="pointer-events-none absolute z-10 hidden h-[180px] w-[320px] bg-cover bg-no-repeat"
+          className="pointer-events-none absolute z-10 hidden h-full w-full bg-cover bg-no-repeat"
         />
         <VideoPlayer
           setQuality={setQuality}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -28,7 +28,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between py-4 transition-all [&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center justify-between py-4 transition-all [&[data-state=open]>svg]:rotate-180 text-start',
         className,
       )}
       {...props}


### PR DESCRIPTION
### PR Fixes

**Resolves**: #1624 #1577


- Adjusted the iframe width, which was previously hardcoded, causing misalignment on larger screens. The iframe now has a responsive relative width and maintains an aspect ratio for proper positioning inside the video container.
- **Fixed an issue where the last accordion item was hidden due to a previous commit that shifted the sidebar to the bottom by a few pixels.** Increased the padding-bottom of the sidebar to resolve this and made the text alignment of the accordion items left-aligned to ensure a coherent appearance on smaller devices.

---

### Screenshots of Changes

#### **Before vs. After Comparison**

| **Screen Size** | **Before**                                                                                                 | **After**                                                                                                  |
|------------------|----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| **4K Screen**   | <img width="849" alt="Before 4K" src="https://github.com/user-attachments/assets/8001df57-2ff1-4437-8618-049c6b01c496"> | <img width="848" alt="After 4K" src="https://github.com/user-attachments/assets/5f96275f-631d-4a88-89bf-c657a0dd49dd"> |
| **Laptop Screen**| <img width="853" alt="Before Laptop" src="https://github.com/user-attachments/assets/73bd2ea6-5dd9-4767-8f6e-da06e8d326ed"> | <img width="854" alt="After Laptop" src="https://github.com/user-attachments/assets/aef41fed-2111-45f6-a56c-98f03c191550"> |

---


### Accordion and Navbar Fixes Before and After on Mobile Device

| **Before**                                  | **After**                                   |
|---------------------------------------------|---------------------------------------------|
| <img width="226" alt="Screenshot 2024-12-07 at 9 17 55 PM" src="https://github.com/user-attachments/assets/e05e7dd0-b0fb-4a03-b3e4-4ee6605daab9"> | <img width="222" alt="Screenshot 2024-12-11 at 11 43 26 PM" src="https://github.com/user-attachments/assets/25754e0c-74ae-4ba5-bff5-0472de3be005" /> |


Note: I’ve just fixed the accordion styling. However, there’s still an issue with displaying content inside the buttons. Since there are already pull requests open to address this, I won’t be working on it for now.

---

### Checklist Before Requesting Review

- [x] I have performed a self-review of my code.
- [x] I confirm there are no duplicate pull requests for the same issue.

@devsargam @siinghd 
