### PR TITLE
fix#1627: remove unnecessary space between header and breadcrumb

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[90px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
### PR Fixes:
- 1 Made the breadcrumb stick to the header while scrolling.

Resolves #1627 

### Checklist before requesting a review
- [✅] I have performed a self-review of my code
- [✅ ] I assure there is no similar/duplicate pull request regarding same issue

screenshot
![image](https://github.com/user-attachments/assets/9b41191b-9b73-4362-a15e-369c4cf95d0f)

