### PR TITLE
feat: add responsive design for breadcrumb

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -21,15 +21,15 @@ export const CourseView = ({
   rest: string[];
   course: any;
   courseContent:
-    | {
-        folder: true;
-        value: ChildCourseContent[];
-      }
-    | {
-        folder: false;
-        value: ChildCourseContent;
-      }
-    | null;
+  | {
+    folder: true;
+    value: ChildCourseContent[];
+  }
+  | {
+    folder: false;
+    value: ChildCourseContent;
+  }
+  | null;
   nextContent: any;
   searchParams: QueryParams;
   possiblePath: string;
@@ -39,8 +39,8 @@ export const CourseView = ({
     : courseContent?.value.type;
 
   return (
-    <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[90px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+    <div className="relative flex w-full flex-col gap-6 pb-16 pt-8 sm:gap-4 sm:pb-12 sm:pt-6 md:gap-6 md:pb-14 xl:pt-[9px]">
+      <div className="sticky top-[73px] z-10 flex flex-col gap-3 bg-background sm:gap-2 sm:py-2 md:gap-3 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
### PR Fixes:
- Fixed gap between breadcrumb and header on smaller screens
- Improved responsiveness of breadcrumb and header layout 

Resolves 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

### Screenshots:

### Mobile View
<img width="629" alt="Screenshot 2024-12-07 at 10 31 16 PM" src="https://github.com/user-attachments/assets/853356c1-251b-4cf3-83f0-7df260f0b903">

<br />
<img width="1440" alt="Screenshot 2024-12-07 at 10 30 46 PM" src="https://github.com/user-attachments/assets/67c1c681-adfb-44e2-b72f-8badfb2350b5">
<br />



