### PR TITLE
fix: enable sign in button when firefox autofills credentials

### DIFF
--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -151,6 +151,7 @@ const Signin = () => {
 
   // Handle clicks outside the dropdown
   useEffect(() => {
+    // Handle clicks outside the dropdown
     const handleClickOutside = (event: MouseEvent) => {
       if (
         dropdownRef.current &&
@@ -159,12 +160,30 @@ const Signin = () => {
         setSuggestedDomains([]);
       }
     };
-
-    document.addEventListener('mousedown', handleClickOutside);
+  
+    // Check for autofill on component mount
+    const checkAutofill = () => {
+      const emailField = document.getElementById('email') as HTMLInputElement;
+      const passwordField = document.getElementById('password') as HTMLInputElement;
+  
+      if (emailField?.value) {
+        email.current = emailField.value;
+        setRequiredError((prevState) => ({ ...prevState, emailReq: false }));
+      }
+  
+      if (passwordField?.value) {
+        password.current = passwordField.value;
+        setRequiredError((prevState) => ({ ...prevState, passReq: false }));
+      }
+    };
+      document.addEventListener('mousedown', handleClickOutside);
+      const autofillTimeout = setTimeout(checkAutofill, 100);
+  
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      clearTimeout(autofillTimeout); 
     };
-  }, []);
+  }, []);  
 
   return (
     <section className="wrapper relative flex min-h-screen items-center justify-center overflow-hidden antialiased">
@@ -201,6 +220,7 @@ const Signin = () => {
                 placeholder="name@email.com"
                 value={email.current}
                 onChange={handleEmailChange}
+                onInput={handleEmailChange}
                 onKeyDown={handleKeyDown}
                 onBlur={() => setSuggestedDomains([])} // Hide suggestions on blur
               />


### PR DESCRIPTION
### PR Fixes:
- Fixed an issue where the submit button wasn't disabling on Firefox when autofill was used.
- Optimized the autofill detection logic by moving it to a dedicated `useEffect` for better performance and readability.

Resolves #[1650].

https://github.com/user-attachments/assets/5b806fb6-6fe0-40f8-93bf-483678188454



### Checklist Before Requesting a Review:
- [x] I have performed a thorough self-review of my code to ensure quality and adherence to best practices.
- [x] I confirm that no similar or duplicate pull requests exist for the same issue or functionality.