### PR TITLE
Fix the sticky video path; it now stays at the top while scrolling.

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -39,8 +39,8 @@ export const CourseView = ({
     : courseContent?.value.type;
 
   return (
-    <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+    <div className="relative flex z-0 w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
+      <div className="sticky top-[72px] z-10 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
PR Fixes:
1.This PR fixes the issue where the path to the video remains sticky at the top when scrolling through comments
2.The sticky behavior is removed.

Resolves #1653 

Checklist before requesting a review
[✅ ] I have performed a self-review of my code
[✅ ] I assure there is no similar/duplicate pull request regarding same issue
