### PR TITLE
Bug-fix: Vertical misalignment of "Ctrl + K" icon inside the search bar #1703

### DIFF
--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -179,8 +179,8 @@ export function SearchBar({ onCardClick, isMobile = false }: SearchBarProps) {
         {state.searchTerm.length === 0 &&
           !isMobile &&
           (icon !== '⌘' ? (
-            <kbd className="pointer-events-none absolute right-3 top-2.5 inline-flex h-5 select-none items-center gap-1 rounded border border-gray-200 bg-gray-100 px-1.5 font-mono text-[10px] font-medium text-gray-600 opacity-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 sm:block">
-              <span className="text-xs">{icon}</span>K
+            <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 inline-flex h-5 select-none items-center gap-1 rounded border border-gray-200 bg-gray-100 px-1.5 font-mono text-[10px] font-medium text-gray-600 opacity-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+              <span className="text-xs leading-none">{icon}K</span>
             </kbd>
           ) : (
             <kbd className="pointer-events-none absolute right-3 top-2.5 inline-flex h-5 select-none items-center gap-1 rounded border border-gray-200 bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">


### PR DESCRIPTION
### **PR Fixes**:  
- Fixed vertical misalignment of the "Ctrl + K" icon inside the search bar.  
### Before
![image](https://github.com/user-attachments/assets/4a1b1ec2-cdce-45c4-a2fe-63fbc41427b5)
### After
![image](https://github.com/user-attachments/assets/71110c88-96a3-4265-ab04-4e52c9d34d2a)

  

Resolves #1703   

---

### **Checklist before requesting a review**  
- [x] I have performed a self-review of my code.  
- [x] I have ensured there is no similar/duplicate pull request addressing the same issue.  
- [x] I have tested the changes on multiple screen sizes and themes (light/dark).  
- [x] I have included screenshots or GIFs to demonstrate the fix.