### PR TITLE
Fix : CheckCircle2 Icon Overlapping Navbar on Scroll #1716

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-20 flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
changed z-index for CheckCircle2 icon to follow the stacking context and remain hidden behind the navbar when scrolling.

### PR Fixes:
- 1 updated z-index
- 2  CheckCircle2 icon remain hidden behind the navbar while scrolling.

Resolves #1716 

Before
![WhatsApp Image 2025-01-16 at 23 29 47_cfd3eecf](https://github.com/user-attachments/assets/172ffb09-4c9c-4965-aee9-17e889afce02)

After
![WhatsApp Image 2025-01-16 at 23 29 47_b1c793e2](https://github.com/user-attachments/assets/0c8fd799-d97b-4dde-ac68-f5129add940f)

