### PR TITLE
Fix: Ensure CheckCircle2 respects navbar z-index on scroll

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-20 flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
### PR Fixes:
- 1 Adjusted the `z-index` of the navbar in courseView.jsx to 20 to ensure it stays above all card components, including the `CheckCircle2` icon.
- 2 Fixed stacking context issues causing the `CheckCircle2` icon to overlap the navbar when scrolling.

Resolves #1716  

### Checklist before requesting a review
- [x] I have performed a self-review of my code
