### PR TITLE
displayed a message when no watched content

### DIFF
--- a/src/components/FolderView.tsx
+++ b/src/components/FolderView.tsx
@@ -16,6 +16,7 @@ export const FolderView = ({
 }) => {
   const router = useRouter();
 
+
   if (!courseContent?.length) {
     return (
       <div className="mt-64 flex">
@@ -23,19 +24,25 @@ export const FolderView = ({
       </div>
     );
   }
-  let updatedRoute = `/courses/${courseId}`;
-  for (let i = 0; i < rest.length; i++) {
-    updatedRoute += `/${rest[i]}`;
-  }
-  // why? because we have to reset the segments or they will be visible always after a video
-
   const currentfilter = useRecoilValue(selectFilter);
-
   const filteredCourseContent = getFilteredContent(
     courseContent,
     currentfilter,
   );
-
+  if (!filteredCourseContent?.length) {
+    return (
+        <div className="mt-60 flex">
+            <div className="m-auto text-gray-500 text-xl">
+                No {currentfilter} content found in this section.
+            </div>
+        </div>
+    );
+}
+let updatedRoute = `/courses/${courseId}`;
+  for (let i = 0; i < rest.length; i++) {
+    updatedRoute += `/${rest[i]}`;
+  }
+  // why? because we have to reset the segments or they will be visible always after a video
   return (
     <div>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
### PR Fixes:
It has properly displayed the message if there is no watched content instead of an empty black screen.

Resolves #1725

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
<img width="1470" alt="Screenshot 2025-01-27 at 3 20 56 PM" src="https://github.com/user-attachments/assets/dc289eeb-7f7c-4465-97a1-16a5f5e52063" />
