### PR TITLE
Added appropriate message for filter #1725

### DIFF
--- a/src/components/FolderView.tsx
+++ b/src/components/FolderView.tsx
@@ -36,6 +36,23 @@ export const FolderView = ({
     currentfilter,
   );
 
+  if (filteredCourseContent?.length === 0) {
+    const filterMessages: Record<string, string> = {
+      watched: "You haven't completed any content in this section yet.",
+      watching: "No content currently in progress.",
+      unwatched: "No new content available to watch.",
+      all: "No content available in this section.",
+    };
+  
+    return (
+      <div className="mt-56 flex">
+        <div className="m-auto text-center text-gray-500 text-xl">
+          {filterMessages[currentfilter] || "No content found."}
+        </div>
+      </div>
+    );
+  }
+  
   return (
     <div>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/src/components/FolderView.tsx
+++ b/src/components/FolderView.tsx
@@ -37,7 +37,7 @@ export const FolderView = ({
   );
 
   if (filteredCourseContent?.length === 0) {
-    const filterMessages: Record<string, string> = {
+    const filterMessages = {
       watched: "You haven't completed any content in this section yet.",
       watching: "No content currently in progress.",
       unwatched: "No new content available to watch.",


### PR DESCRIPTION
### PR Fixes:
- 1 A short and simple message displayed when filtered content is null to make a better user experience.
- 2 Displays different message for different filter.

Resolves #1725 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
![Screenshot 2025-01-29 143849](https://github.com/user-attachments/assets/0488dbd1-4132-4cab-bc6a-beb68d7c259a)
![Screenshot 2025-01-29 143913](https://github.com/user-attachments/assets/b941db31-b59a-479e-a597-4f0dac6f2576)

