### PR TITLE
Updated AppxVideoPlayer.tsx - Added full screen feature on double click

### DIFF
--- a/src/components/AppxVideoPlayer.tsx
+++ b/src/components/AppxVideoPlayer.tsx
@@ -40,5 +40,16 @@ export const AppxVideoPlayer = ({
     src={url}
     className="w-full rounded-lg aspect-video"
     allowFullScreen
+    onDoubleClick={(e) => {           // Full screen on double click
+      if (e.currentTarget.requestFullscreen) {
+        e.currentTarget.requestFullscreen();
+      } else if (e.currentTarget.mozRequestFullScreen) { // Firefox
+        e.currentTarget.mozRequestFullScreen();
+      } else if (e.currentTarget.webkitRequestFullscreen) { // Chrome, Safari, and Opera
+        e.currentTarget.webkitRequestFullscreen();
+      } else if (e.currentTarget.msRequestFullscreen) { // IE/Edge
+        e.currentTarget.msRequestFullscreen();
+      }
+    }}
   ></iframe >;
 };


### PR DESCRIPTION
### PR Fixes:

I was facing some issues, and, wanted a feature, to make the video go to full screen on double click, just like YouTube, as, clicking on that little icon multiple times was quite annoying. So, I have added this feature to make video go full screen on double click.
