### PR TITLE
Typographical error fix in /bookmark

### DIFF
--- a/src/components/bookmark/NoBookmark.tsx
+++ b/src/components/bookmark/NoBookmark.tsx
@@ -13,7 +13,7 @@ const NoBookmark = () => {
         className="size-[40%] min-w-[400px] opacity-90 invert dark:invert-0"
       />
       <h1 className="lg:font-5xl text-center text-2xl font-bold text-black dark:text-white">
-        Well.. You have&apos;nt Bookmarked anything yet....
+      Well, you haven't bookmarked anything yet.
       </h1>
       <p className="text-center text-lg max-sm:text-base sm:w-[400px]">
         💡When you find something you want to save for later, Click the &ldquo;


### PR DESCRIPTION
### PR Fixes:
- 1 Fixed typographical error when there is no bookmarks 
- Before 
![image](https://github.com/user-attachments/assets/ea8bb440-2c0c-4f3b-90c5-081dc8ced3f4)

- After 
![image](https://github.com/user-attachments/assets/c189556e-3bf3-4b0f-9015-6bacc474e4be)


Resolves #1738 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
