### PR TITLE
Bug fix - CheckMark & Play icon overlapping

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -51,12 +51,12 @@ export const ContentCard = ({
             className={`group relative flex h-fit w-full max-w-md cursor-pointer flex-col gap-2 rounded-2xl transition-all duration-300 hover:-translate-y-2`}
           >
             {markAsCompleted && (
-              <div className="absolute right-2 top-2 z-10">
+              <div className="absolute right-2 top-2 z-[9]">
                 <CheckCircle2 color="green" size={30} fill="lightgreen" />
               </div>
             )}
             {type === 'video' && (
-              <div className="absolute bottom-12 right-2 z-10 rounded-md p-2 font-semibold text-white">
+              <div className="absolute bottom-12 right-2 z-[9] rounded-md p-2 font-semibold text-white">
                 <Play className="size-6" />
               </div>
             )}


### PR DESCRIPTION
### PR Fixes:
- 1 Reduced z index of check mark icon and playicon to 9
- 2 This will stop overlapping

Resolves #[I faced this so thats why raised this PR] 

### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue

### Bug preview link - https://jam.dev/c/f427eac6-e241-41a1-b12b-b924bebcae47
### Fix preview link - https://jam.dev/c/749cace3-1bbc-4276-a225-edd874119a6c
