### PR TITLE
fix: fixed the issue of Copying entire code snippet on text selection

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -22,13 +22,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ block }) => {
   return (
     <div className="w-full overflow-auto py-2">
       <pre
-        onClick={handleCopy}
         className="group relative flex cursor-pointer justify-between rounded-lg border border-primary/5 bg-neutral-50 p-6 dark:bg-neutral-900"
       >
         <code className="overflow-auto font-mono text-primary">{code}</code>
-        <div className="absolute right-4 top-4 flex flex-col text-primary/50 transition-all duration-300 group-hover:opacity-100 lg:opacity-25">
+        <button onClick={handleCopy} className="absolute right-4 top-4 flex flex-col text-primary/50 transition-all duration-300 group-hover:opacity-100 lg:opacity-25">
           <Copy className="size-4 text-primary/50" />
-        </div>
+        </button>
       </pre>
     </div>
   );


### PR DESCRIPTION
### PR Fixes  the issue of Copying entire code snippet on text selection,

now,Only the selected portion of the code snippet is highlighted.


Resolves  #1764

![image](https://github.com/user-attachments/assets/e6f775cd-22da-46fc-bac7-a0972129cb8a)

![image](https://github.com/user-attachments/assets/776af677-6103-4ea4-b180-354e6e1f451b)

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
