### PR TITLE
feat(video): Add event listeners for mouse long-press to increase the speed, 0 for start over same as in youtube

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -22,13 +22,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ block }) => {
   return (
     <div className="w-full overflow-auto py-2">
       <pre
-        onClick={handleCopy}
         className="group relative flex cursor-pointer justify-between rounded-lg border border-primary/5 bg-neutral-50 p-6 dark:bg-neutral-900"
       >
         <code className="overflow-auto font-mono text-primary">{code}</code>
-        <div className="absolute right-4 top-4 flex flex-col text-primary/50 transition-all duration-300 group-hover:opacity-100 lg:opacity-25">
+        <button onClick={handleCopy} className="absolute right-4 top-4 flex flex-col text-primary/50 transition-all duration-300 group-hover:opacity-100 lg:opacity-25">
           <Copy className="size-4 text-primary/50" />
-        </div>
+        </button>
       </pre>
     </div>
   );


### PR DESCRIPTION
### PR added :
-  event listeners for mouse long-press to increase the speed to 2X
- releasing the long-press continues with previous playback speed
- '0' for startover the video
-  Arrow up and down for changing the volume by 10%

Resolves #1776 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
