### PR TITLE
persist scroll position on page navigation

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { CheckCircle2, Play } from 'lucide-react';
 import { Bookmark } from '@prisma/client';
 import BookmarkButton from './bookmark/BookmarkButton';
@@ -11,7 +12,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from './ui/tooltip';
-import React from 'react';
+import React, { useEffect,useRef } from 'react';
 
 export const ContentCard = ({
   title,
@@ -37,6 +38,28 @@ export const ContentCard = ({
   uploadDate?: string;
   weeklyContentTitles?: string[];
 }) => {
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const savedScrollY = sessionStorage.getItem("scrollPosition");
+    if (savedScrollY) {
+      window.scrollTo(0, parseInt(savedScrollY, 10));
+    }
+
+    const handleScrollY = () => {
+      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+      scrollTimeoutRef.current = setTimeout(() => {
+        sessionStorage.setItem("scrollPosition", window.scrollY.toString());
+      }, 200); // Adjust the delay as needed
+    };
+
+    window.addEventListener("scroll", handleScrollY);
+    return () => {
+      window.removeEventListener("scroll", handleScrollY);
+      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+    };
+  }, []);
+
   return (
     <TooltipProvider delayDuration={0}>
       <Tooltip>


### PR DESCRIPTION
Issue: you will see bunch of videos when you open a purchased course, if you scroll to some video like 14th or 15 or to end and opens it and return back you will got to see the scroll position to 0. Again you need to scroll to open a neighbour video of previous one.

### PR Fixes:
- 1 Restored scroll position of purchased course videos tab
- 2 open a video of a course comes back you will stay on the scroll position you are at

Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [* ] I have performed a self-review of my code
- [* ] I assure there is no similar/duplicate pull request regarding same issue
