### PR TITLE
Fix pip bug on brave

### DIFF
--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -67,7 +67,7 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
       if (document.pictureInPictureElement) {
         await document.exitPictureInPicture();
       } else if (document.pictureInPictureEnabled && playerRef.current) {
-        playerRef.current.requestPictureInPicture();
+        await playerRef.current.requestPictureInPicture()
       }
     } catch (error) {
       // Ignore specific errors that might occur during normal operation
@@ -327,7 +327,6 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
         }
       }
     }
-
     const handleTrackChange = () => {
       for (let i = 0; i < tracks.length; i++) {
         const track = tracks[i];
@@ -503,7 +502,9 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
           event.stopPropagation();
           break;
         case 'KeyP': // 'P' key to toggle picture-in-picture(pip) mode
-          togglePictureInPicture();
+          if(!navigator.brave) {
+            togglePictureInPicture();
+          }
           event.stopPropagation();
           break;
         case 'KeyC':
@@ -652,8 +653,10 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
             .el()
             .insertBefore(qualitySelector.el(), fullscreenToggle.el());
 
-          const pipButton = createPipButton(player);
-          controlBar.el().insertBefore(pipButton.el(), fullscreenToggle.el());
+            if(!navigator.brave) {
+              const pipButton = createPipButton(player);
+              controlBar.el().insertBefore(pipButton.el(), fullscreenToggle.el());
+            }
 
           setPlayer(player);
           if (options.isComposite) {


### PR DESCRIPTION
## Before

**Brave :-**
Brave Browser Overrides Video Player in Picture-in-Picture (PiP) Mode
After clicking the PiP fullscreen button in Brave, a download button appears.
It feels like hackers don’t even need to struggle to hack the video.

![Screenshot 2025-03-26 192700](https://github.com/user-attachments/assets/95d4c72e-c0fe-40b3-bf78-d0fb4b9e668b)

##  After 
**Brave :-** 
![Screenshot 2025-03-28 024419](https://github.com/user-attachments/assets/f45bce7e-7249-44b2-b8ee-0efd6de07a22)
**Chrome/other  :-** 
![Screenshot 2025-03-28 024355](https://github.com/user-attachments/assets/e41a8fa0-7779-4fe1-8e88-0718b9c93c01)

I can remove Picture-in-Picture (PiP) for Brave because it seems like a hacky way to download resources locally.

