### PR TITLE
Add video fullscreen toggle feature using 'F' for new version of videos

### DIFF
--- a/src/components/AppxVideoPlayer.tsx
+++ b/src/components/AppxVideoPlayer.tsx
@@ -13,6 +13,7 @@ export const AppxVideoPlayer = ({
 }) => {
   const [url, setUrl] = useState('');
   const doneRef = useRef(false);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -33,10 +34,39 @@ export const AppxVideoPlayer = ({
     })();
   }, []);
 
+  useEffect(() => {
+    if(typeof window === 'undefined') {
+      return;
+    }
+    window.addEventListener('keydown', handleKeyPressIframe);
+    return () => {
+      window.removeEventListener('keydown', handleKeyPressIframe);
+    };
+  }, []);
+
+  const handleKeyPressIframe = (event: KeyboardEvent) => {
+    if (event.code === 'KeyF') {
+      event.preventDefault();
+      if (!iframeRef.current) {
+        return;
+      }
+      if (iframeRef.current) {
+        if(!document.fullscreenElement) {
+          iframeRef.current.requestFullscreen();
+        }
+        else if(document.fullscreenElement){
+          document.exitFullscreen();
+        }
+      }
+      
+    }
+  };
+
   if (!url.length) {
     return <p>Loading...</p>;
   }
   return <iframe
+    ref={iframeRef}
     src={url}
     className="w-full rounded-lg aspect-video"
     allowFullScreen

--- a/src/components/AppxVideoPlayer.tsx
+++ b/src/components/AppxVideoPlayer.tsx
@@ -45,20 +45,20 @@ export const AppxVideoPlayer = ({
   }, []);
 
   const handleKeyPressIframe = (event: KeyboardEvent) => {
-    if (event.code === 'KeyF') {
-      event.preventDefault();
-      if (!iframeRef.current) {
-        return;
-      }
-      if (iframeRef.current) {
+    switch(event.code) {
+      case 'KeyF':
+        event.preventDefault();
+        if (!iframeRef.current) {
+          return;
+        }
+        if (iframeRef.current) {
         if(!document.fullscreenElement) {
           iframeRef.current.requestFullscreen();
         }
         else if(document.fullscreenElement){
           document.exitFullscreen();
         }
-      }
-      
+      }      
     }
   };
 


### PR DESCRIPTION
### PR Fixes:
- Fullscreen toggle when user clicks F for new version of videos
- This was already working on older version of videos that uses video-js but not on newer version that depends on iframe

Resolves #1822 

- I couldn't test it with a sample video as I was not able to get cdn url from akamai secure player 
- I tested it using a random embed iframe url and it works

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
