### PR TITLE
FEAT: Remember Last Watched Timestamp in Videos

### DIFF
--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -605,7 +605,7 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
             },
           });
         },
-        Math.ceil((100 * 1000) / player.playbackRate()),
+        Math.ceil((60 * 1000) / player.playbackRate()),
       );
     };
     const handleVideoEnded = (interval: number) => {

--- a/src/db/course.ts
+++ b/src/db/course.ts
@@ -241,11 +241,13 @@ async function getRootCourseContent(courseId: number): Promise<
 export function getVideoProgressForUser(
   userId: string,
   markAsCompleted?: boolean,
+  currentTimestamp?: number
 ) {
   return db.videoProgress.findMany({
     where: {
       userId,
       markAsCompleted,
+      currentTimestamp
     },
   });
 }


### PR DESCRIPTION
### PR Fixes:

- 1 Load the last timestamp recorded when the user was playing the video and start the video from that time.
- 2 Currently I am sending the timestamp update request every 60 seconds.

Resolves #1826

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
