### PR TITLE
enhanced the app bar collapse feature

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,15 +1,27 @@
+"use client";
 import { Appbar } from '@/components/Appbar';
+import { useRecoilValue } from 'recoil';
+import { isSideBarCollapsed } from '@/store/atoms/isSideBarCollabsed';
 import React from 'react';
 
 interface Props {
   children: React.ReactNode;
 }
 
-export default (props: Props) => {
+export default function Layout({ children }: Props) {
+
+  const isCollapsed=useRecoilValue(isSideBarCollapsed);
+
   return (
     <div className="flex min-h-screen w-full">
       <Appbar />
-      <div className="wrapper w-full">{props.children}</div>
+      <main
+        className={`flex-1 transition-all duration-300 ${
+          isCollapsed ? 'ml-[5vw]' : 'ml-[21vw]'
+        }`}
+      >
+        {children}
+      </main>
     </div>
   );
-};
+}

--- a/src/app/courses/layout.tsx
+++ b/src/app/courses/layout.tsx
@@ -1,15 +1,25 @@
+'use client';
 import { Appbar } from '@/components/Appbar';
+import { isSideBarCollapsed } from '@/store/atoms/isSideBarCollabsed';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
 interface Props {
   children: React.ReactNode;
 }
 
 const CourseLayout = (props: Props) => {
+
+  const isCollapsed=useRecoilValue(isSideBarCollapsed);
+
   return (
     <div className="flex min-h-screen">
       <Appbar />
-      <div className="wrapper w-full">{props.children}</div>
+      <div className={`flex-1 transition-all duration-300 ${
+          isCollapsed ? 'ml-[5vw]' : 'ml-[21vw]'
+        }`}
+      >
+        {props.children}</div>
     </div>
   );
 };

--- a/src/components/Appbar.tsx
+++ b/src/components/Appbar.tsx
@@ -10,6 +10,8 @@ import {
 import { SidebarItems } from './ui/sidebar-items';
 import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
+import { isSideBarCollapsed } from '@/store/atoms/isSideBarCollabsed';
+import { useRecoilState } from 'recoil';
 
 export const menuOptions = [
   { id: 1, name: 'Home', Component: Home, href: '/home' },
@@ -45,6 +47,8 @@ export default useMediaQuery;
 
 export const Appbar = () => {
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [isSidebarCollapsed,setIsSidebarCollapsed] = useRecoilState(isSideBarCollapsed);
+  setIsSidebarCollapsed(isCollapsed); 
   const [isMounted, setIsMounted] = useState(false);
   const isMediumToXL = useMediaQuery(
     '(min-width: 768px) and (max-width: 1535px)',
@@ -56,6 +60,7 @@ export const Appbar = () => {
     const handleClickOutside = (event: MouseEvent) => {
       if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node)) {
         setIsCollapsed(true);
+        setIsSidebarCollapsed(true);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -64,7 +69,10 @@ export const Appbar = () => {
     };   
   }, []);
 
-  const toggleCollapse = () => setIsCollapsed(!isCollapsed);
+  const toggleCollapse = () =>{
+     setIsCollapsed(!isCollapsed);
+     setIsSidebarCollapsed(!isSidebarCollapsed);
+    }
 
   const sidebarVariants = {
     expanded: { width: '20vw' },
@@ -88,7 +96,7 @@ export const Appbar = () => {
         className="fixed left-0 top-0 z-[999] hidden h-full flex-col border-r border-primary/10 bg-background dark:bg-background lg:flex min-w-16"
       >
         <div className="flex h-full flex-col gap-4">
-          <div className="flex w-full items-center border-b border-primary/10 px-2 py-4">
+          <div className="flex w-full items-center border-b border-primary/10 px-2 py-3">
             <div>
               <motion.button
                 onClick={toggleCollapse}

--- a/src/store/atoms/isSideBarCollabsed.ts
+++ b/src/store/atoms/isSideBarCollabsed.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isSideBarCollapsed = atom({
+  key: 'isSideBarCollapsed',
+  default: false,
+});


### PR DESCRIPTION
### PR Fixes:
-  Implemented Recoil state for sidebar collapse and dynamic main layout margin.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue


###  **Pull Request: Sidebar Collapse State with Recoil and Dynamic Layout**
###  Summary of Changes

- Introduced a Recoil atom (isSideBarCollapsed) to manage the sidebar’s collapsed state globally.

- Updated Appbar to use useRecoilState for toggling the sidebar collapse state on button click.

- Updated Layout to use useRecoilValue to listen to the sidebar’s collapse state and dynamically adjust the main layout’s margin.

- Wrapped the entire app with RecoilRoot in RootLayout to provide Recoil state management.

- Ensured smooth transitions for layout adjustments using Tailwind’s transition-all and duration-300.

###  **Impact**

- Allows consistent sidebar collapse state across the app.

- Enables dynamic layout adjustment (main content shifting) based on the sidebar state.

- Sets up the groundwork for future state sharing across components using Recoil.

 ### **Testing Steps**
Run the app.

-Click the sidebar toggle button to collapse/expand the sidebar.

-Observe the main content area shifting dynamically (e.g., from ml-[21vw] to ml-[5vw] and back).

-Confirm that state management persists as expected across components.

https://github.com/user-attachments/assets/666e7537-7253-4fbf-b1c9-3510b9e124cb




