### PR TITLE
Fix: Failed to run postgres docker container if it is stopped conditi…

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,12 @@
 # Copies .env.example and changes it to .env so that future commands can find the env file
 cp .env.example .env
 
+# If the container is already running or exists, stop and remove it
+if [ "$(docker ps -aq -f name=cms-db)" ]; then
+  echo "Stopping and removing existing cms-db container..."
+  docker stop cms-db
+  docker rm cms-db
+fi
 
 # Start PostgreSQL container
 docker run -d \


### PR DESCRIPTION
## Bug: Failed to run postgres docker container if it is stopped condition during ./setup.sh run

### PR Fixes:
- 1 Problem statement: If the shell script found any container of the same name cms-db it uses the same container. This works fine if the container is in running condition. But if the container is stopped then also it tries to use the stopped container and failed to do any postgres related action. The same is shown in the problem video here.
- Problem video: 

https://github.com/user-attachments/assets/8e6c3615-3019-4a29-a96d-9c98013ef1cc


- 2 Fix: A conditional check is used before starting the postgres container, if the container of name cms-db is running it will stop and remove the container and start it fresh. The same is shown in the solution video here.
- Solution video: 

https://github.com/user-attachments/assets/7959b1c1-fa93-439f-9412-ed4e1ed1b9e3



Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue
