### PR TITLE
fix: prevent video cards from overlapping breadcrumb navigation

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -51,12 +51,12 @@ export const ContentCard = ({
             className={`group relative flex h-fit w-full max-w-md cursor-pointer flex-col gap-2 rounded-2xl transition-all duration-300 hover:-translate-y-2`}
           >
             {markAsCompleted && (
-              <div className="absolute right-2 top-2 z-10">
+              <div className="absolute right-2 top-2 z-[1]">
                 <CheckCircle2 color="green" size={30} fill="lightgreen" />
               </div>
             )}
             {type === 'video' && (
-              <div className="absolute bottom-12 right-2 z-10 rounded-md p-2 font-semibold text-white">
+              <div className="absolute bottom-12 right-2 z-[1] rounded-md p-2 font-semibold text-white">
                 <Play className="size-6" />
               </div>
             )}


### PR DESCRIPTION
### PR Fixes:
- 1 issue link : https://github.com/code100x/cms/issues/1861
- 2 Breadcrumb Bar Overlapped by Video Cards on Week Video Page

Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [ check] I have performed a self-review of my code
- [check ] I assure there is no similar/duplicate pull request regarding same issue
