### PR TITLE
Fix: Increase z-index of breadcrumb to prevent overlap

### DIFF
--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-20 flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
### 🐞 Bug

On the "Week Videos Listing" page, the breadcrumb bar was being **overlapped by video cards**, making the navigation hard to see or interact with i.e (the video completed green tick icon and the video icon at the bottom right corner)

---

### ✅ Fix

Increased the `z-index` of the breadcrumb div container from `z-10` to `z-20` to ensure it appears above other elements.

---

### 📂 File Modified

- `src/components/CourseView.tsx`

---

### 🔗 Related Issue

Resolves #1861

---

### ✔️ Checklist

- [x] I have performed a self-review of my code
- [x] There is no duplicate PR for this issue
- [x] Only the necessary file is changed (no lockfile or unrelated updates)
- [x] The UI works correctly after the fix

