### PR TITLE
fix: trim whitespace from login credentials

### DIFF
--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -40,7 +40,7 @@ const Signin = () => {
   const password = useRef('');
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
+    const value = e.target.value.trim(); // Trim whitespace
     email.current = value;
 
     setFocusedIndex(0);
@@ -113,6 +113,10 @@ const Signin = () => {
     if (e) {
       e.preventDefault();
     }
+
+    // Trim whitespace before validation
+    email.current = email.current.trim();
+    password.current = password.current.trim();
 
     if (!email.current || !password.current) {
       setRequiredError({


### PR DESCRIPTION
### PR Fixes:
- Applied `.trim()` to the email/username input field to sanitize user input before submission.
- Fixed the issue where accidental leading/trailing whitespace (e.g., from copy-pasting) caused login validation to fail.

Resolves #1900

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue