### PR TITLE
Fix course completion badge overlapping breadcrumb bar

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -51,17 +51,17 @@ export const ContentCard = ({
             className={`group relative flex h-fit w-full max-w-md cursor-pointer flex-col gap-2 rounded-2xl transition-all duration-300 hover:-translate-y-2`}
           >
             {markAsCompleted && (
-              <div className="absolute right-2 top-2 z-10">
+              <div className="absolute right-2 top-2 z-[1]">
                 <CheckCircle2 color="green" size={30} fill="lightgreen" />
               </div>
             )}
             {type === 'video' && (
-              <div className="absolute bottom-12 right-2 z-10 rounded-md p-2 font-semibold text-white">
+              <div className="absolute bottom-12 right-2 z-[1] rounded-md p-2 font-semibold text-white">
                 <Play className="size-6" />
               </div>
             )}
             {type !== 'video' && (
-              <div className="relative overflow-hidden rounded-md">
+              <div className="relative z-0 overflow-hidden rounded-md">
                 <CardComponent
                   title={title}
                   contentDuration={
@@ -80,7 +80,7 @@ export const ContentCard = ({
               </div>
             )}
             {type === 'video' && (
-              <div className="relative overflow-hidden">
+              <div className="relative z-0 overflow-hidden">
                 <VideoThumbnail
                   title={title}
                   contentId={contentId ?? 0}

--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-20 isolate flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
### PR Fixes:
- Fix the stacking order between the sticky breadcrumb/topbar and course card overlays
- Ensure the green completion badge scrolls under the topbar instead of overlapping it

Resolves #1918

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

bug:
<img width="1440" height="858" alt="Screenshot 2026-04-07 at 5 33 35 PM" src="https://github.com/user-attachments/assets/32e9646d-840a-4bd9-a78d-78d1bf754c5e" />

fix:
<img width="1440" height="858" alt="Screenshot 2026-04-07 at 5 34 04 PM" src="https://github.com/user-attachments/assets/a57bed2c-89c4-4442-a2aa-e0bb47d8dd11" />
