### PR TITLE
fix: update Dockerfile.dev to fix bcrypt and OpenSSL issues

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,16 +1,11 @@
-FROM node:20-alpine
-
+FROM node:20-bullseye-slim
 WORKDIR /usr/src/app
-
+RUN apt-get update && apt-get install -y openssl python3 make g++ && rm -rf /var/lib/apt/lists/*
 COPY package.json pnpm-lock.yaml ./
 COPY prisma ./prisma
-
 RUN npm i pnpm -g
-
-RUN pnpm install
-
+RUN pnpm install --ignore-scripts=false
+RUN cd node_modules/.pnpm/bcrypt@5.1.1/node_modules/bcrypt && npm rebuild
 COPY . .
-
 EXPOSE 3000
-
 CMD ["pnpm", "dev:docker"]


### PR DESCRIPTION
## Problem
Docker setup failing on Linux due to:
1. bcrypt native module not compiling
2. OpenSSL 1.1 missing on Alpine 3.23

## Fix
- Change base image from node:20-alpine 
  to node:20-bullseye-slim
- Add build dependencies: openssl, python3, make, g++
- Add --ignore-scripts=false to pnpm install
- Add explicit bcrypt rebuild step
- Fixes bcrypt_lib.node not found error on Linux

## PR Fixes:
- bcrypt compilation error
- OpenSSL missing on Alpine 3.23

Resolves #[leave empty if no issue]

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request