### PR TITLE
fix: add missing env vars to docker-compose and fix Greeting hydration bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/cms?schema=public
       - NEXT_WEBPACK_USEPOLLING=1
+      - NEXT_PUBLIC_BASE_URL_LOCAL=http://localhost:3000
+      - NEXTAUTH_URL=http://localhost:3000
+      - NEXTAUTH_SECRET=NEXTAUTH_SECRET
+      - JWT_SECRET=JWT_SECRET
+      - ADMIN_SECRET=ADMIN_SECRET
+      - LOCAL_CMS_PROVIDER=true
     ports:
       - '3000:3000'
       - '5555:5555'

--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-export const Greeting = () => {
-  // Get the current hour
-  const currentHour = new Date().getHours();
+import { useEffect, useState } from 'react';
 
-  // Determine the appropriate greeting based on the time of day
-  let greeting;
-  if (currentHour >= 4 && currentHour < 12) {
-    greeting = 'Good Morning';
-  } else if (currentHour >= 12 && currentHour < 17) {
-    greeting = 'Good Afternoon';
-  } else if (currentHour >= 17 && currentHour <= 20) {
-    greeting = 'Good Evening';
-  } else {
-    greeting = 'Happy to see you back!';
-  }
+const getGreeting = () => {
+  const currentHour = new Date().getHours();
+  if (currentHour >= 4 && currentHour < 12) return 'Good Morning';
+  if (currentHour >= 12 && currentHour < 17) return 'Good Afternoon';
+  if (currentHour >= 17 && currentHour <= 20) return 'Good Evening';
+  return 'Happy to see you back!';
+};
+
+export const Greeting = () => {
+  const [greeting, setGreeting] = useState('');
+
+  useEffect(() => {
+    setGreeting(getGreeting());
+  }, []);
 
   return greeting;
 };


### PR DESCRIPTION
### What does this PR do?

- Adds missing environment variables to `docker-compose.yml` so the app works out of the box without manual `.env` edits
- Fixes a React hydration mismatch in `Greeting.tsx` caused by time-based greeting differing between server and client render

### Changes

**docker-compose.yml**
- Added `LOCAL_CMS_PROVIDER`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `JWT_SECRET`, `ADMIN_SECRET` to the environment block
- Added `NEXT_PUBLIC_BASE_URL_LOCAL` so API calls resolve correctly inside the container

**src/components/Greeting.tsx**
- Moved time-based greeting logic into `useEffect` with `useState('')` initial value
- Server and client now agree on the initial render, eliminating the hydration error

### Why?

Without these env vars, Docker login would fail with `TypeError: Failed to parse URL from undefined/post/userLogin`. New contributors had no way to know which vars were missing since only `DATABASE_URL` was passed to the container.

The Greeting hydration bug caused the entire root to switch to client rendering, flooding the console with errors on every page load.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue