### PR TITLE
feat: add spacebar hold for 2x speed in player with proper listener c…

### DIFF
--- a/src/components/VideoPlayer2.tsx
+++ b/src/components/VideoPlayer2.tsx
@@ -364,6 +364,9 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
       return;
     }
     let volumeSetTimeout: ReturnType<typeof setInterval> | null = null;
+    let isSpaceHeld = false;
+    let previousPlaybackRate = 1;
+
     const handleKeyPress = (event: KeyboardEvent) => {
       const isShiftPressed = event.shiftKey;
       const isModifierPressed = event.metaKey || event.ctrlKey || event.altKey;
@@ -440,15 +443,18 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
       }
 
       switch (event.code) {
-        case 'Space': // Space bar for play/pause
-          if (player.paused()) {
-            player.play();
-            event.stopPropagation();
-          } else {
-            player.pause();
-            event.stopPropagation();
-          }
+        case 'Space': // Space bar for 2x speed hold
           event.preventDefault();
+          if (event.repeat) {
+            if (!isSpaceHeld) {
+              isSpaceHeld = true;
+              previousPlaybackRate = player.playbackRate();
+              player.playbackRate(2);
+              if (player.paused()) {
+                player.play();
+              }
+            }
+          }
           break;
         case 'ArrowRight': // Right arrow for seeking forward 5 seconds
           player.currentTime(player.currentTime() + 5);
@@ -558,16 +564,26 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
           break;
       }
     };
-    const handleKeyUp = (event: any) => {
+    const handleKeyUp = (event: KeyboardEvent) => {
       if (event.code === 'KeyT') {
         player.playbackRate(1);
+      }
+      if (event.code === 'Space') {
+        event.preventDefault();
+        if (isSpaceHeld) {
+          isSpaceHeld = false;
+          player.playbackRate(previousPlaybackRate);
+          return;
+        } 
+        player.paused() ? player.play(): player.pause() 
       }
     };
     document.addEventListener('keydown', handleKeyPress, { capture: true });
     document.addEventListener('keyup', handleKeyUp);
     // Cleanup function
     return () => {
-      document.removeEventListener('keydown', handleKeyPress);
+      document.removeEventListener('keydown', handleKeyPress,  { capture: true });
+      document.removeEventListener('keyup', handleKeyUp);
     };
   }, [player]);
 


### PR DESCRIPTION
### **What was missing**
The player had no way to temporarily boost speed by holding a key. This PR adds the spacebar hold gesture which is a common pattern in video players (e.g. YouTube).

### **What was added**
- Holding space kicks the playback rate to 2x
- Releasing space restores the previous playback rate (not hardcoded to 1x — respects whatever rate the user was already at)
- If the video was paused when the hold started, it auto-plays during the hold
- A quick tap of space still toggles play/pause as expected

| Action | Result |
|---|---|
| Hold space | Playback jumps to 2x |
| Release space | Restores previous rate |
| Tap space while playing | Pauses |
| Tap space while paused | Plays |
| Hold space while paused | Auto-plays at 2x, restores on release |


### Cleanup Logic 
Both listeners are correctly registered and removed:

`keydown` is registered with `{ capture: true }` so it fires before Video.js 
internal handlers can intercept it. The removal must mirror the same flag — 
without it, the browser treats capture and non-capture registrations as distinct 
listeners and the removal becomes a no-op, leaking the listener on every unmount.

`keyup` removal was simply absent, causing a new duplicate listener to stack up 
on every re-render triggered by `player` state changes.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
