### PR TITLE
fix: breadcrumb z-index to prevent completion mark  overlapping stick…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@prisma/client': true
+  '@prisma/engines': true
+  bcrypt: true
+  esbuild: true
+  prisma: true

--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-20 flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}


### PR DESCRIPTION
## Problem
When scrolling, the completion checkmark badge on ContentCard was 
appearing above the sticky breadcrumb header due to CSS transforms 
creating a new stacking context.

## Fix
- Increased breadcrumb z-index from z-10 to z-20 in CourseView
- This ensures cards scroll correctly beneath the sticky header

## Testing
- Navigate to any course folder
- Scroll down — cards should go below the sticky breadcrumb
- Completion badge should not overlap the header