### PR TITLE
fix: prevent user ID spoofing by stripping client-supplied 'g' header in withMobileAuth

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@prisma/client': true
+  '@prisma/engines': true
+  bcrypt: true
+  esbuild: true
+  prisma: true

--- a/src/components/CourseView.tsx
+++ b/src/components/CourseView.tsx
@@ -40,7 +40,7 @@ export const CourseView = ({
 
   return (
     <div className="relative flex w-full flex-col gap-8 pb-16 pt-8 xl:pt-[9px]">
-      <div className="sticky top-[73px] z-10 flex flex-col gap-4 bg-background py-2 xl:pt-2">
+      <div className="sticky top-[73px] z-20 flex flex-col gap-4 bg-background py-2 xl:pt-2">
         <BreadCrumbComponent
           course={course}
           contentType={contentType}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,8 +29,17 @@ export const verifyJWT = async (token: string): Promise<JWTPayload | null> => {
 };
 
 export const withMobileAuth = async (req: RequestWithUser) => {
-  if (req.headers.get('Auth-Key')) {
-    return NextResponse.next();
+
+  const authKey=req.headers.get('Auth-Key');
+   
+  if (authKey && authKey===process.env.APPX_AUTH_KEY) {
+      const newHeaders = new Headers(req.headers);
+      newHeaders.delete('g');
+      return NextResponse.next({
+      request: {
+        headers: newHeaders,
+      },
+    });
   }
   const token = req.headers.get('Authorization');
 


### PR DESCRIPTION
## Problem
The `withMobileAuth` middleware in `/src/middleware.ts` had two vulnerabilities:

**Vulnerability 1 — Auth-Key not validated:**
The original code only checked if `Auth-Key` header existed, not its value:
```ts
if (req.headers.get('Auth-Key')) {  // ← any value passed!
  return NextResponse.next();
}
```

**Vulnerability 2 — Client-supplied `g` header not stripped:**
When `Auth-Key` matched, the middleware called `NextResponse.next()` 
without stripping the incoming headers. This meant an attacker could:

1. Send a valid `Auth-Key` 
2. Attach their own `g: {"id": "admin-user-id"}` header
3. The endpoint blindly trusted it:

```ts
// route.ts — trusted client-supplied g as if server set it
const user: { id: string } = JSON.parse(request.headers.get('g') || '');
```

Attack looked like this:
```bash
curl -H "Auth-Key: validkey" \
     -H 'g: {"id": "some-admin-id"}' \
     https://site.com/api/mobile/courses/123
```

---

## Fix

```ts
const authKey = req.headers.get('Auth-Key');

if (authKey && authKey === process.env.APPX_AUTH_KEY) {
  const newHeaders = new Headers(req.headers);
  newHeaders.delete('g');  // ← strip spoofed g header
  return NextResponse.next({
    request: { headers: newHeaders },
  });
}
```

Two things fixed:
1. `Auth-Key` value is now validated against `process.env.APPX_AUTH_KEY`
2. Client-supplied `g` header is deleted before forwarding the request

The JWT path was already safe since it overwrites `g` with 
`newHeaders.set('g', JSON.stringify(payload))` — a server-verified value.

---

## Security Impact
Before fix → attacker could access any user's course data by spoofing their ID  
After fix → `g` header is always either absent or server-generated, never client-trusted

Fixes #1924