### PR TITLE
fix: recursively calculate nested course progress percentage

### DIFF
--- a/src/db/course.ts
+++ b/src/db/course.ts
@@ -166,7 +166,7 @@ export const getNextVideo = async (currentVideoId: number) => {
   return latestContent;
 };
 
-async function getAllContent(): Promise<
+export async function getAllContent(): Promise<
   {
     id: number;
     type: string;

--- a/src/utiles/appx.ts
+++ b/src/utiles/appx.ts
@@ -2,6 +2,7 @@ import {
   getAllCoursesAndContentHierarchy,
   getAllVideos,
   getVideoProgressForUser,
+  getAllContent,
 } from '@/db/course';
 import { authOptions } from '@/lib/auth';
 import { Course } from '@/store/atoms';
@@ -153,7 +154,7 @@ export async function getPurchases(email: string): Promise<CoursesResponse> {
     session?.user?.id || '',
     true,
   );
-  const allVideos = await getAllVideos();
+  const allContents = await getAllContent();
 
   const completedVideosLookup: { [key: string]: boolean } =
     userVideoProgress?.reduce((acc: any, progress) => {
@@ -161,18 +162,34 @@ export async function getPurchases(email: string): Promise<CoursesResponse> {
       return acc;
     }, {});
 
+  const childrenMap = new Map<number, number[]>();
+  allContents.forEach(c => {
+    if (c.parentId) {
+      if (!childrenMap.has(c.parentId)) childrenMap.set(c.parentId, []);
+      childrenMap.get(c.parentId)!.push(c.id);
+    }
+  });
+
   const courses = _courses.map((course) => {
     let totalVideos = 0;
     let totalVideosWatched = 0;
+    
     course.content.forEach(({ contentId }) => {
-      allVideos.forEach(({ parentId, id }) => {
-        if (parentId === contentId) {
-          totalVideos++;
-          if (completedVideosLookup[id]) {
-            totalVideosWatched++;
-          }
+      const queue: number[] = [contentId];
+      while(queue.length > 0) {
+        const currentId = queue.shift()!;
+        const content = allContents.find(c => c.id === currentId);
+        
+        if (content?.type === 'video') {
+           totalVideos++;
+           if (completedVideosLookup[currentId]) {
+              totalVideosWatched++;
+           }
         }
-      });
+        
+        const children = childrenMap.get(currentId) || [];
+        queue.push(...children);
+      }
     });
 
     return {


### PR DESCRIPTION
## Summary

Fixes an issue where course progress percentage was not increasing after completing lectures because the content traversal logic failed to recursively walk down nested subfolders.

---

## Detailed Changes

### Course Progress Recalculation
* **Files Modified:**
  * `src/db/course.ts`
  * `src/utiles/appx.ts`
* **Explanation:**
  * Exported the `getAllContent` utility function from `src/db/course.ts`.
  * Reimplemented the `totalVideos` and `totalVideosWatched` counting logic inside the `getPurchases` helper function (`src/utiles/appx.ts`) using a Breadth-First Search (BFS) / recursive traversal.
  * Previously, progress only calculated top-level videos. Now, it accurately walks down all nested subfolders to calculate the total and completed video counts, updating the user's progress bar correctly when any lecture is finished.
  
<img width="1919" height="1034" alt="Screenshot 2026-06-13 010609" src="https://github.com/user-attachments/assets/14154847-06ba-4a52-b86d-ca3ef8622d4a" />

